### PR TITLE
Fix StreamingService crashing Story/Storybook discovery

### DIFF
--- a/src/matchDescendants.luau
+++ b/src/matchDescendants.luau
@@ -13,7 +13,11 @@ local function matchDescendants(parent: Instance, predicate: (descendant: Instan
 	end
 
 	for _, descendant in parent:GetDescendants() do
-		if predicate(descendant) then
+		local success, result = pcall(function()
+			return predicate(descendant)
+		end)
+
+		if success and result == true then
 			table.insert(matches, descendant)
 		end
 	end

--- a/src/matchDescendants.spec.luau
+++ b/src/matchDescendants.spec.luau
@@ -27,3 +27,11 @@ test("returns an array of instances that match the predicate", function()
 
 	container:Destroy()
 end)
+
+test("never throws when attempting to traverse services with higher security clearance", function()
+	expect(function()
+		matchDescendants(game, function(descendant)
+			return descendant:IsA("Instance")
+		end)
+	end).never.toThrow()
+end)


### PR DESCRIPTION
# Problem

When traversing the DataModel for Stories and Storybooks, we attempt to traverse over StreamingService which out of nowhere is throwing errors even when attempting to index it

# Solution

The crash was happening in `isStorybookModule` but `matchDescendants` is a better place for this logic, so I've added a test case and fix for this crash
