### PR TITLE
Fix Roact element rendering

### DIFF
--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -135,6 +135,22 @@ test("update the component on arg changes", function()
 	expect(button.Text).toBe("Enabled")
 end)
 
+test("renders primitives", function()
+	local story = createReactStory(React.createElement("TextLabel", {
+		Text = "Hello, World",
+	}))
+
+	render(container, story)
+
+	act(function()
+		task.wait()
+	end)
+
+	local label = container:FindFirstChildWhichIsA("TextLabel")
+	assert(label, "no TextLabel found")
+	expect(label.Text).toBe("Hello, World")
+end)
+
 test("lifecycle", function()
 	expect(#container:GetChildren()).toBe(0)
 

--- a/src/renderers/createRoactRenderer.luau
+++ b/src/renderers/createRoactRenderer.luau
@@ -6,23 +6,35 @@ type Packages = {
 	Roact: any,
 }
 
+local function isRoactElement(maybeElement: any): boolean
+	if typeof(maybeElement) == "table" then
+		return maybeElement.component and maybeElement.props
+	end
+	return false
+end
+
 local function createRoactRenderer(packages: Packages): StoryRenderer<unknown>
 	local Roact = packages.Roact
 	local tree
-	local currentElement
+	local currentComponent
 
 	local function mount(container, story, props)
-		if typeof(story.story) == "function" then
-			currentElement = Roact.createElement(story.story, props)
+		local element
+
+		if isRoactElement(story.story) then
+			currentComponent = story.story.component
+			element = story.story
 		else
-			currentElement = story.story
+			currentComponent = story.story
+			element = Roact.createElement(currentComponent, props)
 		end
-		tree = Roact.mount(currentElement, container, "RoactRenderer")
+
+		tree = Roact.mount(element, container, "RoactRenderer")
 	end
 
 	local function update(props)
-		if tree and currentElement then
-			local element = Roact.createElement(currentElement, props)
+		if tree and currentComponent then
+			local element = Roact.createElement(currentComponent, props)
 			Roact.update(tree, element)
 		end
 	end

--- a/src/renderers/createRoactRenderer.luau
+++ b/src/renderers/createRoactRenderer.luau
@@ -12,9 +12,12 @@ local function createRoactRenderer(packages: Packages): StoryRenderer<unknown>
 	local currentElement
 
 	local function mount(container, story, props)
-		currentElement = story.story
-		local renderedElement = Roact.createElement(story.story, props)
-		tree = Roact.mount(renderedElement, container, "RoactRenderer")
+		if typeof(story.story) == "function" then
+			currentElement = Roact.createElement(story.story, props)
+		else
+			currentElement = story.story
+		end
+		tree = Roact.mount(currentElement, container, "RoactRenderer")
 	end
 
 	local function update(props)

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -95,6 +95,33 @@ test("update the component on arg changes", function()
 	expect(button.Text).toBe("Enabled")
 end)
 
+test("render a pre-created Roact element", function()
+	local function TextLabelStory()
+		return Roact.createElement("TextLabel", {
+			Text = "Hello, World",
+		})
+	end
+	local story = createRoactStory(Roact.createElement(TextLabelStory))
+
+	render(container, story)
+
+	local element = container:FindFirstChildOfClass("TextLabel")
+	assert(element, "no element found")
+	expect(element.Text).toBe("Hello, World")
+end)
+
+test("renders primitives", function()
+	local story = createRoactStory(Roact.createElement("TextLabel", {
+		Text = "Hello, World",
+	}))
+
+	render(container, story)
+
+	local label = container:FindFirstChildWhichIsA("TextLabel")
+	assert(label, "no TextLabel found")
+	expect(label.Text).toBe("Hello, World")
+end)
+
 test("lifecycle", function()
 	expect(#container:GetChildren()).toBe(0)
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipbook-labs/storyteller"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
# Problem

Setting a story to be the result of `Roact.createElement(FooComponent)` results in errors. This is an expect use case for Roact stories that don't accept controls and should be supported

# Solution

Added support for pre-made Roact elements and also took a pass to make sure React and Roact primitives could be rendered as well
