### PR TITLE
Accommodate analysis errors in flipbook's recent PR

### DIFF
--- a/src/createRendererForStory.luau
+++ b/src/createRendererForStory.luau
@@ -4,7 +4,7 @@ local createReactRenderer = require("@root/renderers/createReactRenderer")
 local createRoactRenderer = require("@root/renderers/createRoactRenderer")
 local types = require("@root/types")
 
-type Story<T> = types.Story<T>
+type LoadedStory<T> = types.LoadedStory<T>
 type StoryRenderer<T> = types.StoryRenderer<T>
 
 --[[
@@ -18,7 +18,7 @@ type StoryRenderer<T> = types.StoryRenderer<T>
 	@tag Story
 	@within Storyteller
 ]]
-local function createRendererForStory<T>(story: Story<T>): StoryRenderer<any>
+local function createRendererForStory<T>(story: LoadedStory<T>): StoryRenderer<any>
 	local packages = if story.packages then story.packages else story.storybook.packages
 	if packages then
 		if packages.Roact then

--- a/src/findStoryModulesForStorybook.luau
+++ b/src/findStoryModulesForStorybook.luau
@@ -13,7 +13,7 @@ local types = require("@root/types")
 	@within Storyteller
 	@since 0.1.0
 ]=]
-local function findStoryModulesForStorybook(storybook: types.Storybook): { ModuleScript }
+local function findStoryModulesForStorybook(storybook: types.LoadedStorybook): { ModuleScript }
 	local storyModules = {}
 	for _, root in storybook.storyRoots do
 		storyModules = Sift.List.join(

--- a/src/findStoryModulesForStorybook.spec.luau
+++ b/src/findStoryModulesForStorybook.spec.luau
@@ -25,7 +25,8 @@ test("find all story modules for a storybook", function()
 		container = folder
 	end
 
-	local storybook: types.Storybook = {
+	local storybook: types.LoadedStorybook = {
+		name = "Storybook",
 		storyRoots = {
 			container,
 		},

--- a/src/hooks/useStory.luau
+++ b/src/hooks/useStory.luau
@@ -60,9 +60,9 @@ local function useStory(
 	module: ModuleScript,
 	storybook: types.Storybook,
 	loader: ModuleLoader.ModuleLoader
-): (types.Story<unknown>?, string?)
+): (types.LoadedStory<unknown>?, string?)
 	local state, setState = React.useState({} :: {
-		story: types.Story<unknown>?,
+		story: types.LoadedStory<unknown>?,
 		err: string?,
 	})
 

--- a/src/hooks/useStory.luau
+++ b/src/hooks/useStory.luau
@@ -58,7 +58,7 @@ local types = require("@root/types")
 ]=]
 local function useStory(
 	module: ModuleScript,
-	storybook: types.Storybook,
+	storybook: types.LoadedStorybook,
 	loader: ModuleLoader.ModuleLoader
 ): (types.LoadedStory<unknown>?, string?)
 	local state, setState = React.useState({} :: {

--- a/src/hooks/useStorybooks.luau
+++ b/src/hooks/useStorybooks.luau
@@ -60,7 +60,7 @@ local types = require("@root/types")
 	@tag Storybook
 	@within Storyteller
 ]=]
-local function useStorybooks(parent: Instance, loader: ModuleLoader.ModuleLoader): { types.Storybook }
+local function useStorybooks(parent: Instance, loader: ModuleLoader.ModuleLoader): { types.LoadedStorybook }
 	local storybooks, setStorybooks = React.useState({})
 
 	local loadStorybooks = React.useCallback(function()

--- a/src/init.luau
+++ b/src/init.luau
@@ -17,6 +17,7 @@ local types = require("./types")
 
 export type RenderLifecycle = types.RenderLifecycle
 export type Story<T> = types.Story<T>
+export type LoadedStory<T> = types.LoadedStory<T>
 export type Storybook = types.Storybook
 export type StoryControls = types.StoryControls
 export type StoryProps = types.StoryProps

--- a/src/init.luau
+++ b/src/init.luau
@@ -19,6 +19,7 @@ export type RenderLifecycle = types.RenderLifecycle
 export type Story<T> = types.Story<T>
 export type LoadedStory<T> = types.LoadedStory<T>
 export type Storybook = types.Storybook
+export type LoadedStorybook = types.LoadedStorybook
 export type StoryControls = types.StoryControls
 export type StoryProps = types.StoryProps
 export type StoryRenderer<T> = types.StoryRenderer<T>

--- a/src/loadStoryModule.luau
+++ b/src/loadStoryModule.luau
@@ -6,7 +6,7 @@ local migrateLegacyPackages = require("@root/migrateLegacyPackages")
 local types = require("@root/types")
 
 type StoryPackages = types.StoryPackages
-type Storybook = types.Storybook
+type LoadedStorybook = types.LoadedStorybook
 type LoadedStory<T> = types.LoadedStory<T>
 
 --[=[
@@ -31,7 +31,7 @@ type LoadedStory<T> = types.LoadedStory<T>
 local function loadStoryModule<T>(
 	loader: ModuleLoader.ModuleLoader,
 	storyModule: ModuleScript,
-	storybook: Storybook
+	storybook: LoadedStorybook
 ): LoadedStory<T>
 	local success, result = pcall(function()
 		return loader:require(storyModule)

--- a/src/loadStoryModule.luau
+++ b/src/loadStoryModule.luau
@@ -7,7 +7,7 @@ local types = require("@root/types")
 
 type StoryPackages = types.StoryPackages
 type Storybook = types.Storybook
-type Story<T> = types.Story<T>
+type LoadedStory<T> = types.LoadedStory<T>
 
 --[=[
 	Loads the source of a Story module.
@@ -32,7 +32,7 @@ local function loadStoryModule<T>(
 	loader: ModuleLoader.ModuleLoader,
 	storyModule: ModuleScript,
 	storybook: Storybook
-): Story<T>
+): LoadedStory<T>
 	local success, result = pcall(function()
 		return loader:require(storyModule)
 	end)

--- a/src/loadStoryModule.spec.luau
+++ b/src/loadStoryModule.spec.luau
@@ -9,11 +9,13 @@ local jest = JestGlobals.jest
 local test = JestGlobals.test
 local expect = JestGlobals.expect
 
-local MOCK_PLAIN_STORYBOOK: types.Storybook = {
+local MOCK_PLAIN_STORYBOOK: types.LoadedStorybook = {
+	name = "Plain Storybook",
 	storyRoots = {},
 }
 
-local MOCK_ROACT_STORYBOOK: types.Storybook = {
+local MOCK_ROACT_STORYBOOK: types.LoadedStorybook = {
+	name = "Roact Storybook",
 	storyRoots = {},
 	packages = {
 		Roact = {
@@ -24,7 +26,8 @@ local MOCK_ROACT_STORYBOOK: types.Storybook = {
 	},
 }
 
-local MOCK_REACT_STORYBOOK: types.Storybook = {
+local MOCK_REACT_STORYBOOK: types.LoadedStorybook = {
+	name = "React Storybook",
 	storyRoots = {},
 	packages = {
 		React = {
@@ -141,7 +144,8 @@ describe("legacy support", function()
 	test("packages attached to the story get grouped in `packages` object", function()
 		local loader = ModuleLoader.new()
 
-		local storybook: types.Storybook = {
+		local storybook: types.LoadedStorybook = {
+			name = "Storybook",
 			storyRoots = {},
 		}
 
@@ -167,7 +171,8 @@ describe("legacy support", function()
 	test("packages attached to the story take precedence over the storybook", function()
 		local loader = ModuleLoader.new()
 
-		local storybook: types.Storybook = {
+		local storybook: types.LoadedStorybook = {
+			name = "Storybook",
 			storyRoots = {},
 			packages = {
 				Roact = {},

--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -18,7 +18,7 @@ local types = require("@root/types")
 	@tag Module Loading
 	@within Storyteller
 ]=]
-local function loadStorybookModule(loader: ModuleLoader.ModuleLoader, module: ModuleScript): types.Storybook
+local function loadStorybookModule(loader: ModuleLoader.ModuleLoader, module: ModuleScript): types.LoadedStorybook
 	local wasRequired, result = pcall(function()
 		return loader:require(module)
 	end)

--- a/src/render.luau
+++ b/src/render.luau
@@ -3,7 +3,7 @@ local Sift = require("@pkg/Sift")
 local createRendererForStory = require("@root/createRendererForStory")
 local types = require("@root/types")
 
-type Story<T> = types.Story<T>
+type LoadedStory<T> = types.LoadedStory<T>
 type StoryControls = types.StoryControls
 type StoryProps = types.StoryProps
 type StoryRenderer<T> = types.StoryRenderer<T>
@@ -75,7 +75,7 @@ end
 	@tag Rendering
 	@within Storyteller
 ]=]
-local function render<T>(container: Instance, story: Story<T>): RenderLifecycle
+local function render<T>(container: Instance, story: LoadedStory<T>): RenderLifecycle
 	local renderer = createRendererForStory(story)
 
 	local prevProps: StoryProps?

--- a/src/render.spec.luau
+++ b/src/render.spec.luau
@@ -11,7 +11,7 @@ local test = JestGlobals.test
 type StoryRenderer<T> = types.StoryRenderer<T>
 
 local container: Instance
-local story: types.Story<TextLabel>
+local story: types.LoadedStory<TextLabel>
 local mockCreateRendererForStory = jest.fn()
 local render
 

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -2,7 +2,7 @@ local Sift = require("@pkg/Sift")
 
 local types = require("@root/types")
 
-type Story<T> = types.Story<T>
+type LoadedStory<T> = types.LoadedStory<T>
 type StoryProps = types.StoryProps
 type StoryRenderer<T> = types.StoryRenderer<T>
 
@@ -15,7 +15,7 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 
 	local handle: Instance?
 
-	local function mount(container: Instance, story: Story<Instance>, props: StoryProps)
+	local function mount(container: Instance, story: LoadedStory<Instance>, props: StoryProps)
 		if typeof(story.story) == "Instance" then
 			handle = story.story
 		elseif typeof(story.story) == "function" then

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -1,7 +1,7 @@
 local types = require("@root/types")
 
 type StoryProps = types.StoryProps
-type Story<T> = types.Story<T>
+type LoadedStory<T> = types.LoadedStory<T>
 type StoryRenderer<T> = types.StoryRenderer<T>
 
 type CleanupFn = () -> ()
@@ -12,7 +12,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 	local currentStory
 	local cleanup: (() -> ())?
 
-	local function mount(container: Instance, story: Story<ManualStory>, props: StoryProps)
+	local function mount(container: Instance, story: LoadedStory<ManualStory>, props: StoryProps)
 		currentContainer = container
 		currentStory = story
 

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -21,7 +21,7 @@ local function createReactRenderer(packages: Packages): StoryRenderer<unknown>
 	local root
 	local currentStory
 
-	local function reactRender(story: types.Story<unknown>, props)
+	local function reactRender(story: types.LoadedStory<unknown>, props)
 		local element
 		if isReactElement(story.story) then
 			element = story.story

--- a/src/test-utils/createStory.luau
+++ b/src/test-utils/createStory.luau
@@ -1,6 +1,6 @@
 local types = require("@root/types")
 
-local function createStory<T>(element: T, packages: types.StoryPackages?): types.Story<T>
+local function createStory<T>(element: T, packages: types.StoryPackages?): types.LoadedStory<T>
 	return {
 		name = "Sample",
 		story = element,

--- a/src/types.luau
+++ b/src/types.luau
@@ -20,7 +20,7 @@ export type RenderLifecycle = {
 }
 
 export type StoryRenderer<T> = {
-	mount: (container: Instance, story: Story<T>, initialProps: StoryProps) -> (),
+	mount: (container: Instance, story: LoadedStory<T>, initialProps: StoryProps) -> (),
 	unmount: (() -> ())?,
 	update: ((props: StoryProps, prevProps: StoryProps?) -> ())?,
 	transformProps: ((props: StoryProps, prevProps: StoryProps?) -> StoryProps)?,
@@ -43,7 +43,7 @@ types.IStorybook = t.interface({
 	packages = t.optional(t.map(t.string, t.any)),
 })
 
-export type Story<T> = {
+export type LoadedStory<T> = {
 	name: string,
 	story: T | (props: StoryProps) -> T,
 	source: ModuleScript,
@@ -52,6 +52,15 @@ export type Story<T> = {
 
 	summary: string?,
 	controls: StoryControls?,
+}
+
+export type Story<T> = {
+	story: T | (props: StoryProps) -> T,
+
+	controls: StoryControls?,
+	name: string?,
+	packages: StoryPackages?,
+	summary: string?,
 }
 types.IStory = t.interface({
 	story = t.any,

--- a/src/types.luau
+++ b/src/types.luau
@@ -43,15 +43,11 @@ types.IStorybook = t.interface({
 	packages = t.optional(t.map(t.string, t.any)),
 })
 
-export type LoadedStory<T> = {
+export type LoadedStorybook = {
 	name: string,
-	story: T | (props: StoryProps) -> T,
-	source: ModuleScript,
-	storybook: Storybook,
-	packages: StoryPackages?,
+	storyRoots: { Instance },
 
-	summary: string?,
-	controls: StoryControls?,
+	packages: StoryPackages?,
 }
 
 export type Story<T> = {
@@ -69,5 +65,16 @@ types.IStory = t.interface({
 	controls = t.optional(t.map(t.string, t.any)),
 	packages = t.optional(t.map(t.string, t.any)),
 })
+
+export type LoadedStory<T> = {
+	name: string,
+	story: T | (props: StoryProps) -> T,
+	source: ModuleScript,
+	storybook: Storybook,
+	packages: StoryPackages?,
+
+	summary: string?,
+	controls: StoryControls?,
+}
 
 return types

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipbook-labs/storyteller"
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
# Problem

Trying to update flipbook's docs and part of that involves analyzing code samples. But that's currently failing because Storyteller's Story and Storybook types are too strict

https://github.com/flipbook-labs/flipbook/pull/276

# Solution

Created new `LoadedStory` and`LoadedStorybook` types which have all the implicitly defined properties that a user doesn't need to worry about. `Story` and `Storybook` are now slimmed down
