### PR TITLE
Fix support for legacy stories when packages are supplied on the storybook

### DIFF
--- a/src/e2e/storybooks/Hoarcekat.storybook.luau
+++ b/src/e2e/storybooks/Hoarcekat.storybook.luau
@@ -1,7 +1,14 @@
 local Root = script:FindFirstAncestor("e2e")
 
+local Roact = require("@pkg/Roact")
+
 return {
 	storyRoots = {
 		Root.stories.hoarcekat,
+	},
+	-- Packages are included for Hoarcekat to ensure the rendering logic does
+	-- _not_ attempt to render the stories with them.
+	packages = {
+		Roact = Roact,
 	},
 }

--- a/src/loadStoryModule.luau
+++ b/src/loadStoryModule.luau
@@ -41,8 +41,10 @@ local function loadStoryModule<T>(
 		error(`Failed to load story {storyModule:GetFullName()}. Error: {result})`)
 	end
 
+	local isLegacyStory = typeof(result) == "function"
+
 	-- Support for Hoarcekat stories
-	if typeof(result) == "function" then
+	if isLegacyStory then
 		local callback = result
 		result = {
 			story = function(props)
@@ -60,19 +62,22 @@ local function loadStoryModule<T>(
 		)
 	end
 
-	local packages = migrateLegacyPackages(result)
+	local story: types.Story<T> = result
+
+	local packages = migrateLegacyPackages(story)
 	if not packages then
 		packages = storybook.packages
 	end
 
-	local story = Sift.Dictionary.merge({
+	local loadedStory: types.LoadedStory<T> = {
 		name = storyModule.Name:gsub(constants.STORY_NAME_PATTERN, ""),
 		storybook = storybook,
 		source = storyModule,
-		packages = packages,
-	}, result)
+		story = story.story,
+		packages = if isLegacyStory then {} else packages,
+	}
 
-	return story
+	return Sift.Dictionary.merge(loadedStory, story)
 end
 
 return loadStoryModule


### PR DESCRIPTION
# Problem

Discovered this issue in Flipbook https://github.com/flipbook-labs/flipbook/issues/279

Hoarcekat stories weren't always working and the reason for this is because the storybook was passing Roact through `packages`, which then tried to implicitly render the Hoarcekat story with Roact rather than using the manual renderer

# Solution

To fix this, I've first setup the e2e Hoarcekat storybook to supply Roact as a package, which reproduces the issue. Then patched the bug in loadStoryModule by discarding the packages from the storybook when loading legacy stories 