### PR TITLE
Add support for nameless Storybooks

### DIFF
--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -34,7 +34,12 @@ local function loadStorybookModule(loader: ModuleLoader.ModuleLoader, module: Mo
 	end
 
 	if not result.name then
-		result.name = module.Name:gsub(constants.STORYBOOK_NAME_PATTERN, "")
+		local name = module.Name:gsub(constants.STORYBOOK_NAME_PATTERN, "")
+		if name == "" then
+			result.name = "Unnamed Storybook"
+		else
+			result.name = name
+		end
 	end
 
 	return result

--- a/src/loadStorybookModule.spec.luau
+++ b/src/loadStorybookModule.spec.luau
@@ -46,6 +46,20 @@ test("use the name of the storybook module by default", function()
 	expect(storybook.name).toBe("SampleStorybook")
 end)
 
+test("nameless storybook", function()
+	local loader = ModuleLoader.new()
+	local storybookModule = createMockStorybookModule([[
+		return {
+			storyRoots = {}
+		}
+	]])
+	storybookModule.Name = ".storybook"
+
+	local storybook = loadStorybookModule(loader, storybookModule)
+
+	expect(storybook.name).toBe("Unnamed Storybook")
+end)
+
 test("generic failures for storybook", function()
 	local loader = ModuleLoader.new()
 	local storybookModule = createMockStorybookModule([[


### PR DESCRIPTION
# Problem

User request to have unnamed Storybook modules in the form `.storybook.luau` where the `name` field must be explicitly supplied, otherwise defaulting to "Unnamed Storybook"

# Solution

Implemented the above request

Resolves #27 
