### PR TITLE
Add tests for React hooks

### DIFF
--- a/src/hooks/useStory.spec.luau
+++ b/src/hooks/useStory.spec.luau
@@ -1,0 +1,145 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local ModuleLoader = require("@pkg/ModuleLoader")
+local ReactRoblox = require("@pkg/ReactRoblox")
+
+local renderHook = require("@root/test-utils/renderHook")
+local types = require("@root/types")
+local useStory = require("./useStory")
+
+local beforeEach = JestGlobals.beforeEach
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+local act = ReactRoblox.act
+
+type LoadedStorybook = types.LoadedStorybook
+
+local loader: ModuleLoader.ModuleLoader
+local container: Folder
+local componentModule: ModuleScript
+local storyModule: ModuleScript
+local storybook: types.LoadedStorybook
+
+beforeEach(function()
+	loader = ModuleLoader.new()
+
+	container = Instance.new("Folder")
+
+	componentModule = Instance.new("ModuleScript")
+	componentModule.Name = "Component"
+	componentModule.Source = [[
+		local function Component(props)
+			local label = Instance.new("TextButton")
+			label.Text = "Click Me"
+
+			return label
+		end
+
+		return Component
+	]]
+	componentModule.Parent = container
+
+	storyModule = Instance.new("ModuleScript")
+	storyModule.Name = "Sample.story"
+	storyModule.Source = [[
+		local Component = require(script.Parent.Component)
+
+		return {
+			story = Component
+		}
+	]]
+	storyModule.Parent = container
+
+	storybook = {
+		name = "Storybook",
+		storyRoots = { container },
+	}
+end)
+
+test("loads a story module", function()
+	local get = renderHook(function()
+		return useStory(storyModule, storybook, loader)
+	end)
+
+	local story, err = get()
+
+	expect(err).toBeUndefined()
+
+	expect(story).toEqual({
+		name = "Sample",
+		story = expect.any("function"),
+		source = storyModule,
+		storybook = storybook,
+	})
+end)
+
+test("handles story errors", function()
+	storyModule.Source = "syntax error" .. storyModule.Source
+
+	local get = renderHook(function()
+		return useStory(storyModule, storybook, loader)
+	end)
+
+	local story, err = get()
+
+	expect(err).toBeDefined()
+	expect(story).toBeUndefined()
+end)
+
+test("re-renders on module changes", function()
+	local get = renderHook(function()
+		return useStory(storyModule, storybook, loader)
+	end)
+
+	local story, _err = get()
+
+	assert(story ~= nil, "story is undefined")
+	expect(story.name).toBe("Sample")
+
+	storyModule.Source = [[
+		local Component = require(script.Parent.Component)
+
+		return {
+			name = "Foo",
+			story = Component
+		}
+	]]
+
+	-- Wait for engine events
+	act(function()
+		task.wait()
+	end)
+
+	story, _err = get()
+
+	assert(story ~= nil, "story is undefined")
+	expect(story.name).toBe("Foo")
+end)
+
+test("reloads on dependency changes", function()
+	local get = renderHook(function()
+		return useStory(storyModule, storybook, loader)
+	end)
+
+	local story = get()
+
+	componentModule.Source = [[
+		local function Component(props)
+			local label = Instance.new("TextButton")
+			label.Text = "Changed"
+
+			return label
+		end
+
+		return Component
+	]]
+
+	-- Wait for engine events
+	act(function()
+		task.wait()
+	end)
+
+	local newStory = get()
+
+	expect(newStory).never.toBe(story)
+end)

--- a/src/hooks/useStorybooks.luau
+++ b/src/hooks/useStorybooks.luau
@@ -6,6 +6,11 @@ local isStorybookModule = require("@root/isStorybookModule")
 local loadStorybookModule = require("@root/loadStorybookModule")
 local types = require("@root/types")
 
+type UnavailableStorybook = {
+	problem: string,
+	storybook: types.LoadedStorybook,
+}
+
 --[=[
 	Performs all the discovery and loading of Storybook modules that would
 	normally be done via individual API members.
@@ -61,25 +66,41 @@ local types = require("@root/types")
 	@tag Storybook
 	@within Storyteller
 ]=]
-local function useStorybooks(parent: Instance, loader: ModuleLoader.ModuleLoader): { types.LoadedStorybook }
+local function useStorybooks(
+	parent: Instance,
+	loader: ModuleLoader.ModuleLoader
+): {
+	available: { types.LoadedStorybook },
+	unavailable: { UnavailableStorybook },
+}
 	local storybooks, setStorybooks = React.useState({})
+	local unavailableStorybooks, setUnavailableStorybooks = React.useState({} :: { UnavailableStorybook })
 
 	local loadStorybooks = React.useCallback(function()
 		local newStorybooks = {}
+		local newUnavailableStorybooks: { UnavailableStorybook } = {}
 
 		for _, storybookModule in findStorybookModules(parent) do
+			local storybook: types.LoadedStorybook?
 			local success, result = pcall(function()
-				return loadStorybookModule(loader, storybookModule)
+				storybook = loadStorybookModule(loader, storybookModule)
 			end)
 
 			if success then
-				table.insert(newStorybooks, result)
+				table.insert(newStorybooks, storybook)
 			else
-				warn(result)
+				table.insert(newUnavailableStorybooks, {
+					problem = result,
+					storybook = {
+						name = storybookModule.Name,
+						storyRoots = {},
+					},
+				})
 			end
 		end
 
 		setStorybooks(newStorybooks)
+		setUnavailableStorybooks(newUnavailableStorybooks)
 	end, { parent, loader } :: { unknown })
 
 	React.useEffect(function()
@@ -103,7 +124,10 @@ local function useStorybooks(parent: Instance, loader: ModuleLoader.ModuleLoader
 		end
 	end, { loadStorybooks, loader, parent } :: { unknown })
 
-	return storybooks
+	return {
+		available = storybooks,
+		unavailable = unavailableStorybooks,
+	}
 end
 
 return useStorybooks

--- a/src/hooks/useStorybooks.luau
+++ b/src/hooks/useStorybooks.luau
@@ -2,6 +2,7 @@ local ModuleLoader = require("@pkg/ModuleLoader")
 local React = require("@pkg/React")
 
 local findStorybookModules = require("@root/findStorybookModules")
+local isStorybookModule = require("@root/isStorybookModule")
 local loadStorybookModule = require("@root/loadStorybookModule")
 local types = require("@root/types")
 
@@ -82,18 +83,25 @@ local function useStorybooks(parent: Instance, loader: ModuleLoader.ModuleLoader
 	end, { parent, loader } :: { unknown })
 
 	React.useEffect(function()
-		local conn = loader.loadedModuleChanged:Connect(function(other)
-			if types.IStorybook(other) then
+		local function reloadIfStorybook(instance: Instance)
+			if isStorybookModule(instance) then
 				loadStorybooks()
 			end
-		end)
+		end
+
+		local connections = {
+			loader.loadedModuleChanged:Connect(reloadIfStorybook),
+			parent.DescendantAdded:Connect(reloadIfStorybook),
+		}
 
 		loadStorybooks()
 
 		return function()
-			conn:Disconnect()
+			for _, conn in connections do
+				conn:Disconnect()
+			end
 		end
-	end, { loadStorybooks, loader } :: { unknown })
+	end, { loadStorybooks, loader, parent } :: { unknown })
 
 	return storybooks
 end

--- a/src/hooks/useStorybooks.spec.luau
+++ b/src/hooks/useStorybooks.spec.luau
@@ -42,10 +42,34 @@ test("loads storybook modules", function()
 
 	local storybooks = get()
 
-	expect(storybooks).toEqual({
+	expect(storybooks.available).toEqual({
 		{
 			name = "Sample",
 			storyRoots = expect.anything(),
+		},
+	})
+end)
+
+test("storybooks with syntax errors are marked unavailable", function()
+	storybookModule.Source = [[
+		return {
+			syntax error
+		}
+	]]
+
+	local get = renderHook(function()
+		return useStorybooks(container, loader)
+	end)
+
+	local storybooks = get()
+
+	expect(storybooks.unavailable).toEqual({
+		{
+			problem = expect.any("string"),
+			storybook = {
+				name = storybookModule.Name,
+				storyRoots = {},
+			},
 		},
 	})
 end)
@@ -67,7 +91,7 @@ test("adding a new storybook to the DM triggers a re-render", function()
 
 	local storybooks = get()
 
-	expect(storybooks).toEqual({
+	expect(storybooks.available).toEqual({
 		{
 			name = "Sample",
 			storyRoots = expect.anything(),
@@ -80,7 +104,7 @@ test("adding a new storybook to the DM triggers a re-render", function()
 
 	storybooks = get()
 
-	expect(storybooks).toEqual({
+	expect(storybooks.available).toEqual({
 		{
 			name = "Sample",
 			storyRoots = expect.anything(),
@@ -104,7 +128,7 @@ test.skip("removing a storybook from the DM triggers a re-render", function()
 
 	local storybooks = get()
 
-	expect(storybooks).toEqual({})
+	expect(storybooks.available).toEqual({})
 end)
 
 test("re-renders on module changes", function()
@@ -114,7 +138,7 @@ test("re-renders on module changes", function()
 
 	local storybooks = get()
 
-	expect(storybooks).toEqual({
+	expect(storybooks.available).toEqual({
 		{
 			name = "Sample",
 			storyRoots = expect.anything(),
@@ -134,7 +158,7 @@ test("re-renders on module changes", function()
 
 	storybooks = get()
 
-	expect(storybooks).toEqual({
+	expect(storybooks.available).toEqual({
 		{
 			name = "New Name",
 			storyRoots = expect.anything(),

--- a/src/hooks/useStorybooks.spec.luau
+++ b/src/hooks/useStorybooks.spec.luau
@@ -1,0 +1,146 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local ModuleLoader = require("@pkg/ModuleLoader")
+local ReactRoblox = require("@pkg/ReactRoblox")
+
+local renderHook = require("@root/test-utils/renderHook")
+local types = require("@root/types")
+local useStorybooks = require("./useStorybooks")
+
+local beforeEach = JestGlobals.beforeEach
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+local act = ReactRoblox.act
+
+type LoadedStorybook = types.LoadedStorybook
+
+local loader: ModuleLoader.ModuleLoader
+local container: Folder
+local storybookModule: ModuleScript
+
+-- TODO: Create a hierarchy of Storybooks
+-- TODO: Test that a storybook change (like to its name or packages) will re-render
+
+beforeEach(function()
+	loader = ModuleLoader.new()
+
+	container = Instance.new("Folder")
+
+	storybookModule = Instance.new("ModuleScript")
+	storybookModule.Name = "Sample.storybook"
+	storybookModule.Source = [[
+		return {
+			storyRoots = {
+				script.Parent
+			}
+		}
+	]]
+	storybookModule.Parent = container
+end)
+
+test("loads storybook modules", function()
+	local get = renderHook(function()
+		return useStorybooks(container, loader)
+	end)
+
+	local storybooks = get()
+
+	expect(storybooks).toEqual({
+		{
+			name = "Sample",
+			storyRoots = expect.anything(),
+		},
+	})
+end)
+
+test("adding a new storybook to the DM triggers a re-render", function()
+	local newStorybookModule = Instance.new("ModuleScript")
+	newStorybookModule.Name = "Foo.storybook"
+	newStorybookModule.Source = [[
+		return {
+			storyRoots = {
+				script.Parent
+			}
+		}
+	]]
+
+	local get = renderHook(function()
+		return useStorybooks(container, loader)
+	end)
+
+	local storybooks = get()
+
+	expect(storybooks).toEqual({
+		{
+			name = "Sample",
+			storyRoots = expect.anything(),
+		},
+	})
+
+	act(function()
+		newStorybookModule.Parent = container
+	end)
+
+	storybooks = get()
+
+	expect(storybooks).toEqual({
+		{
+			name = "Sample",
+			storyRoots = expect.anything(),
+		},
+		{
+			name = "Foo",
+			storyRoots = expect.anything(),
+		},
+	})
+end)
+
+-- TOOD: Update useStorybooks so this test can pass
+test.skip("removing a storybook from the DM triggers a re-render", function()
+	local get = renderHook(function()
+		return useStorybooks(container, loader)
+	end)
+
+	act(function()
+		storybookModule:Destroy()
+	end)
+
+	local storybooks = get()
+
+	expect(storybooks).toEqual({})
+end)
+
+test("re-renders on module changes", function()
+	local get = renderHook(function()
+		return useStorybooks(container, loader)
+	end)
+
+	local storybooks = get()
+
+	expect(storybooks).toEqual({
+		{
+			name = "Sample",
+			storyRoots = expect.anything(),
+		},
+	})
+
+	act(function()
+		storybookModule.Source = [[
+			return {
+				name = "New Name",
+				storyRoots = {
+					script.Parent
+				}
+			}
+		]]
+	end)
+
+	storybooks = get()
+
+	expect(storybooks).toEqual({
+		{
+			name = "New Name",
+			storyRoots = expect.anything(),
+		},
+	})
+end)

--- a/src/hooks/useStorybooks.spec.luau
+++ b/src/hooks/useStorybooks.spec.luau
@@ -18,9 +18,6 @@ local loader: ModuleLoader.ModuleLoader
 local container: Folder
 local storybookModule: ModuleScript
 
--- TODO: Create a hierarchy of Storybooks
--- TODO: Test that a storybook change (like to its name or packages) will re-render
-
 beforeEach(function()
 	loader = ModuleLoader.new()
 

--- a/src/loadStoryModule.spec.luau
+++ b/src/loadStoryModule.spec.luau
@@ -58,8 +58,12 @@ test("load a story module as a table", function()
 
 	local story = loadStoryModule(loader, storyModule, MOCK_PLAIN_STORYBOOK)
 
-	assert(story ~= nil, "story not defined")
-	expect(story.name).toEqual("Sample")
+	expect(story).toEqual({
+		name = "Sample",
+		source = expect.anything(),
+		story = expect.any("function"),
+		storybook = MOCK_PLAIN_STORYBOOK,
+	})
 end)
 
 test("handle Hoarcekat stories", function()

--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -23,7 +23,7 @@ local function loadStorybookModule(loader: ModuleLoader.ModuleLoader, module: Mo
 		return loader:require(module)
 	end)
 
-	assert(wasRequired, `failed to load storybook`)
+	assert(wasRequired, `failed to load storybook {module:GetFullName()}: {result}`)
 
 	local isStorybook, message = types.IStorybook(result)
 

--- a/src/test-utils/renderHook.luau
+++ b/src/test-utils/renderHook.luau
@@ -1,0 +1,37 @@
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+
+local act = ReactRoblox.act
+
+type Options = {
+	wrapper: React.ComponentType<{
+		children: React.ReactNode,
+	}>,
+}
+
+local function renderHook<T...>(hook: () -> T..., options: Options?): () -> T...
+	local result = React.createRef()
+
+	local function TestComponent()
+		result.current = table.pack(hook())
+	end
+
+	local container = Instance.new("Folder")
+	local root = ReactRoblox.createRoot(container)
+
+	local element = React.createElement(TestComponent)
+
+	if options and options.wrapper then
+		element = React.createElement(options.wrapper, nil, element)
+	end
+
+	act(function()
+		root:render(element)
+	end)
+
+	return function()
+		return table.unpack(result.current)
+	end
+end
+
+return renderHook

--- a/src/test-utils/renderHook.spec.luau
+++ b/src/test-utils/renderHook.spec.luau
@@ -1,0 +1,51 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+local renderHook = require("./renderHook")
+
+local test = JestGlobals.test
+local expect = JestGlobals.expect
+
+local act = ReactRoblox.act
+
+test("works with useState", function()
+	local getHookResult = renderHook(function()
+		return React.useState(1)
+	end)
+
+	local state, setState = getHookResult()
+
+	expect(state).toBe(1)
+
+	act(function()
+		setState(2)
+	end)
+
+	state, setState = getHookResult()
+
+	expect(state).toBe(2)
+end)
+
+test("can supply a wrapper element", function()
+	local context = React.createContext({})
+
+	local function Provider(props): React.Node
+		return React.createElement(context.Provider, {
+			value = {
+				isWrapped = true,
+			},
+		}, props.children)
+	end
+
+	local getHookResult = renderHook(function()
+		return React.useContext(context)
+	end, {
+		wrapper = Provider,
+	})
+
+	local result = getHookResult()
+
+	expect(result).toEqual({
+		isWrapped = true,
+	})
+end)


### PR DESCRIPTION
# Problem

Our React hooks aren't tested and there are some bugs I've been encountering in Flipbook

# Solution

Test React hooks. 

I've also tacked on a change to `useStorybooks` to have it return both available and unavailable storybooks. This will make it possible for Flipbook to show which storybooks were not able to be loaded, along with error info. No more cryptic warnings in the output

Resolves #30 
