### PR TITLE
Add Fusion V3 support to controls

### DIFF
--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -67,7 +67,8 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		if props.controls then
 			local transformed = table.clone(props)
 
-			if not scope then
+			if not scope and Fusion.scoped then
+				-- Fusion V3
 				scope = Fusion:scoped()
 			end
 
@@ -77,7 +78,7 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 				if prevControl then
 					return prevControl
 				else
-					return scope:Value(arg)
+					return if scope then scope:Value(arg) else Fusion.Value(arg)
 				end
 			end)
 

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -14,6 +14,7 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 	local Fusion = packages.Fusion
 
 	local handle: Instance?
+	local scope
 
 	local function mount(container: Instance, story: LoadedStory<Instance>, props: StoryProps)
 		if typeof(story.story) == "Instance" then
@@ -30,6 +31,9 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 	local function unmount()
 		if handle then
 			handle:Destroy()
+		end
+		if scope then
+			scope:doCleanup()
 		end
 	end
 
@@ -63,13 +67,17 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		if props.controls then
 			local transformed = table.clone(props)
 
+			if not scope then
+				scope = Fusion:scoped()
+			end
+
 			transformed.controls = Sift.Dictionary.map(props.controls, function(arg, key)
 				local prevControl = if prevProps and prevProps.controls then prevProps.controls[key] else nil
 
 				if prevControl then
 					return prevControl
 				else
-					return Fusion.Value(arg)
+					return scope:Value(arg)
 				end
 			end)
 


### PR DESCRIPTION
# Problem

Controls are unable to be created with Fusion V3 due to the requirement of scopes.

# Solution

Create an internal scope to store control values when Fusion V3 is detected then clean/clear this scope when unmounted.
