### PR TITLE
Orphan story discovery

### DIFF
--- a/src/findOrphanedStoryModules.luau
+++ b/src/findOrphanedStoryModules.luau
@@ -5,13 +5,15 @@ local matchDescendants = require("@root/matchDescendants")
 local types = require("@root/types")
 
 --[=[
-	Discovers all Story modules that don't have a Storybook targetting them with its `storyRoots`.
+	Discovers all Story modules that do not have a Storybook.
+
+	These are all of the Story modules that are not descendants of an instance
+	in the `storyRoots` array of the given storybooks.
 
 	@tag Storybook
 	@tag Story
 	@tag Discovery
 	@within Storyteller
-	@since 0.1.0
 ]=]
 local function findOrphanedStoryModules(parent: Instance, storybooks: { types.LoadedStorybook }): { ModuleScript }
 	local storyModules = matchDescendants(parent, isStoryModule)

--- a/src/findOrphanedStoryModules.luau
+++ b/src/findOrphanedStoryModules.luau
@@ -1,0 +1,43 @@
+local Sift = require("@pkg/Sift")
+
+local isStoryModule = require("@root/isStoryModule")
+local matchDescendants = require("@root/matchDescendants")
+local types = require("@root/types")
+
+--[=[
+	Discovers all Story modules that don't have a Storybook targetting them with its `storyRoots`.
+
+	@tag Storybook
+	@tag Story
+	@tag Discovery
+	@within Storyteller
+	@since 0.1.0
+]=]
+local function findOrphanedStoryModules(parent: Instance, storybooks: { types.LoadedStorybook }): { ModuleScript }
+	local storyModules = matchDescendants(parent, isStoryModule)
+
+	local storyRoots = Sift.Array.reduce(storybooks, function(accumulated: { Instance }, storybook)
+		return Sift.Array.join(accumulated, storybook.storyRoots)
+	end, {})
+
+	local orphans: { ModuleScript } = {}
+
+	for _, storyModule in storyModules do
+		local isOrphaned = true
+
+		for _, storyRoot in storyRoots do
+			if storyRoot:IsAncestorOf(storyModule) then
+				isOrphaned = false
+				break
+			end
+		end
+
+		if isOrphaned then
+			table.insert(orphans, storyModule :: ModuleScript)
+		end
+	end
+
+	return orphans
+end
+
+return findOrphanedStoryModules

--- a/src/findOrphanedStoryModules.spec.luau
+++ b/src/findOrphanedStoryModules.spec.luau
@@ -15,6 +15,12 @@ beforeEach(function()
 end)
 
 test("finds all Story modules that aren't managed by a Storybook", function()
+	-- Folder
+	--   FolderA
+	--     StoryA.story
+	--   FolderB
+	--     StoryB.story
+
 	local folderA = Instance.new("Folder")
 	folderA.Name = "FolderA"
 	folderA.Parent = container
@@ -41,4 +47,125 @@ test("finds all Story modules that aren't managed by a Storybook", function()
 	}
 
 	expect(findOrphanedStoryModules(container, { storybook })).toEqual({ storyModuleB })
+end)
+
+test("returns empty list when all Story modules are managed by Storybooks", function()
+	-- Folder
+	--   FolderA
+	--     StoryA.story
+	--   FolderB
+	--     StoryB.story
+
+	local folderA = Instance.new("Folder")
+	folderA.Name = "FolderA"
+	folderA.Parent = container
+
+	local storyModuleA = Instance.new("ModuleScript")
+	storyModuleA.Name = "StoryA.story"
+	storyModuleA.Parent = folderA
+
+	local folderB = Instance.new("Folder")
+	folderB.Name = "FolderB"
+	folderB.Parent = container
+
+	local storyModuleB = Instance.new("ModuleScript")
+	storyModuleB.Name = "StoryB.story"
+	storyModuleB.Parent = folderB
+
+	local storybookA: types.LoadedStorybook = {
+		name = "Storybook",
+		loader = ModuleLoader.new(),
+		source = Instance.new("ModuleScript"),
+		storyRoots = {
+			folderA,
+		},
+	}
+
+	local storybookB: types.LoadedStorybook = {
+		name = "Storybook",
+		loader = ModuleLoader.new(),
+		source = Instance.new("ModuleScript"),
+		storyRoots = {
+			folderB,
+		},
+	}
+
+	expect(findOrphanedStoryModules(container, { storybookA, storybookB })).toEqual({})
+end)
+
+test("returns all story modules when no storybooks are present", function()
+	for _ = 1, 5 do
+		local storyModule = Instance.new("ModuleScript")
+		storyModule.Name = "Story.story"
+		storyModule.Parent = container
+	end
+
+	expect(#findOrphanedStoryModules(container, {})).toBe(5)
+end)
+
+test("keeps going after hitting a story along the way", function()
+	local storyModuleA = Instance.new("ModuleScript")
+	storyModuleA.Name = "StoryA.story"
+	storyModuleA.Parent = container
+
+	-- Add Folders above the container to build out a nested hierarchy
+	for _ = 1, 5 do
+		local folder = Instance.new("Folder")
+		container.Parent = folder
+		container = folder
+	end
+
+	-- Place a story in the middle to make sure StoryB will still get picked up
+	local storyModuleB = Instance.new("ModuleScript")
+	storyModuleB.Name = "StoryB.story"
+	storyModuleB.Parent = container
+
+	for _ = 1, 5 do
+		local folder = Instance.new("Folder")
+		container.Parent = folder
+		container = folder
+	end
+
+	expect(findOrphanedStoryModules(container, {})).toEqual({ storyModuleA, storyModuleB })
+end)
+
+test("handles deeply nested stories", function()
+	local storyModuleA = Instance.new("ModuleScript")
+	storyModuleA.Name = "StoryA.story"
+	storyModuleA.Parent = container
+
+	-- Add Folders above the container to build out a nested hierarchy
+	for _ = 1, 10 do
+		local folder = Instance.new("Folder")
+		container.Parent = folder
+		container = folder
+	end
+
+	local folderB = Instance.new("Folder")
+	folderB.Name = "FolderB"
+	folderB.Parent = container
+
+	local storyModuleB = Instance.new("ModuleScript")
+	storyModuleB.Name = "StoryB.story"
+	storyModuleB.Parent = folderB
+
+	local storybookA: types.LoadedStorybook = {
+		name = "Storybook",
+		loader = ModuleLoader.new(),
+		source = Instance.new("ModuleScript"),
+		storyRoots = {
+			container,
+		},
+	}
+
+	local storybookB: types.LoadedStorybook = {
+		name = "Storybook",
+		loader = ModuleLoader.new(),
+		source = Instance.new("ModuleScript"),
+		storyRoots = {
+			folderB,
+		},
+	}
+
+	expect(findOrphanedStoryModules(container, { storybookA, storybookB })).toEqual({})
 end)

--- a/src/findOrphanedStoryModules.spec.luau
+++ b/src/findOrphanedStoryModules.spec.luau
@@ -1,0 +1,44 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local ModuleLoader = require("@pkg/ModuleLoader")
+
+local findOrphanedStoryModules = require("./findOrphanedStoryModules")
+local types = require("@root/types")
+
+local beforeEach = JestGlobals.beforeEach
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+local container
+
+beforeEach(function()
+	container = Instance.new("Folder")
+end)
+
+test("finds all Story modules that aren't managed by a Storybook", function()
+	local folderA = Instance.new("Folder")
+	folderA.Name = "FolderA"
+	folderA.Parent = container
+
+	local storyModuleA = Instance.new("ModuleScript")
+	storyModuleA.Name = "StoryA.story"
+	storyModuleA.Parent = folderA
+
+	local folderB = Instance.new("Folder")
+	folderB.Name = "FolderB"
+	folderB.Parent = container
+
+	local storyModuleB = Instance.new("ModuleScript")
+	storyModuleB.Name = "StoryB.story"
+	storyModuleB.Parent = folderB
+
+	local storybook: types.LoadedStorybook = {
+		name = "Storybook",
+		loader = ModuleLoader.new(),
+		source = Instance.new("ModuleScript"),
+		storyRoots = {
+			folderA,
+		},
+	}
+
+	expect(findOrphanedStoryModules(container, { storybook })).toEqual({ storyModuleB })
+end)

--- a/src/init.luau
+++ b/src/init.luau
@@ -34,6 +34,7 @@ return {
 	-- Discovery
 	findStorybookModules = require("@self/findStorybookModules"),
 	findStoryModulesForStorybook = require("@self/findStoryModulesForStorybook"),
+	findOrphanedStoryModules = require("@self/findOrphanedStoryModules"),
 
 	-- Module loading
 	loadStoryModule = require("@self/loadStoryModule"),


### PR DESCRIPTION
# Problem

Flipbook needs to be able to show a list of all the story modules that don't have a storybook managing them

# Solution

Created a new `findOrphanedStoryModules` function for discovering story modules that aren't managed by a storybook.

In Flipbook, an in-memory storybook will be used so each of these stories can be rendered without the user having to first create a storybook
