### PR TITLE
Roblox internal: Support passing in React using the `Roact` key

### DIFF
--- a/src/migrateLegacyPackages.luau
+++ b/src/migrateLegacyPackages.luau
@@ -1,9 +1,19 @@
+local isReact = require("@root/roblox-internal/isReact")
 local types = require("@root/types")
 
 type StoryPackages = types.StoryPackages
 
 local function migrateLegacyPackages(storyOrStorybook: { [string]: any }): StoryPackages?
 	if storyOrStorybook.roact or storyOrStorybook.react or storyOrStorybook.reactRoblox then
+		do -- Roblox internal. This behavior may be removed without notice.
+			if storyOrStorybook.roact and storyOrStorybook.reactRoblox and isReact(storyOrStorybook.roact) then
+				return {
+					React = storyOrStorybook.roact,
+					ReactRoblox = storyOrStorybook.reactRoblox,
+				}
+			end
+		end
+
 		return {
 			Roact = storyOrStorybook.roact,
 			React = storyOrStorybook.react,

--- a/src/migrateLegacyPackages.spec.luau
+++ b/src/migrateLegacyPackages.spec.luau
@@ -1,0 +1,34 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+local Roact = require("@pkg/Roact")
+
+local migrateLegacyPackages = require("./migrateLegacyPackages")
+
+local describe = JestGlobals.describe
+local test = JestGlobals.test
+local expect = JestGlobals.expect
+
+test("map roact key", function()
+	local packages = migrateLegacyPackages({
+		roact = Roact,
+	})
+
+	expect(packages).toEqual({
+		Roact = Roact,
+	})
+end)
+
+describe("roblox internal", function()
+	test("react can be passed as the roact key", function()
+		local packages = migrateLegacyPackages({
+			roact = React,
+			reactRoblox = ReactRoblox,
+		})
+
+		expect(packages).toEqual({
+			React = React,
+			ReactRoblox = ReactRoblox,
+		})
+	end)
+end)

--- a/src/roblox-internal/isReact.luau
+++ b/src/roblox-internal/isReact.luau
@@ -1,0 +1,18 @@
+--[[
+	This function is used to differentiate between React and legacy Roact only
+	for the consumption of Roblox Internal storybooks.
+]]
+local function isReact(maybeReact: any): boolean
+	if maybeReact.Ref == "ref" and maybeReact.Children == "children" then
+		return true
+	-- Legacy Roact is a strict table, and indexing it directly throws an error
+	-- if a member doesn't exist. To get around this we use rawget to check if
+	-- it's React
+	elseif rawget(maybeReact, "useState") ~= nil then
+		return true
+	else
+		return false
+	end
+end
+
+return isReact

--- a/src/roblox-internal/isReact.spec.luau
+++ b/src/roblox-internal/isReact.spec.luau
@@ -1,0 +1,26 @@
+local JestGlobals = require("@pkg/JestGlobals")
+local React = require("@pkg/React")
+local ReactRoblox = require("@pkg/ReactRoblox")
+local Roact = require("@pkg/Roact")
+local RoactCompat = require("@pkg/RoactCompat")
+
+local isReact = require("./isReact")
+
+local test = JestGlobals.test
+local expect = JestGlobals.expect
+
+test("React is React", function()
+	expect(isReact(React)).toBeTruthy()
+end)
+
+test("RoactCompat is React", function()
+	expect(isReact(RoactCompat)).toBeTruthy()
+end)
+
+test("ReactRoblox is not React", function()
+	expect(isReact(ReactRoblox)).toBeFalsy()
+end)
+
+test("legacy Roact is not React", function()
+	expect(isReact(Roact)).toBeFalsy()
+end)

--- a/wally.toml
+++ b/wally.toml
@@ -23,6 +23,7 @@ React = "jsdotlua/react@17.0.2"
 # [dev-dependencies]
 ReactRoblox = "jsdotlua/react-roblox@17.0.2"
 Roact = "roblox/roact@1.4.4"
+RoactCompat = "jsdotlua/roact-compat@17.0.2"
 Fusion = "elttob/fusion@0.2.0"
 Fusion3 = "elttob/fusion@0.3.0"
 Jest = "jsdotlua/jest@3.10.0"


### PR DESCRIPTION
# Problem

Developer Storybook supplies the React/ReactRoblox package using `roact` and `reactRoblox` on the storybook object and we need to support that too

# Solution

To handle this case, I've added an `isReact` function which is used to check if the `roact` key is actually React when migrating packages.

This allows Roblox-internal stories to continue using `roact` and `reactRoblox`, which will be implicitly migrated to `packages.React` and `packages.ReactRoblox` 
