### PR TITLE
Map `storyRoot` to `storyRoots`

### DIFF
--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -30,6 +30,15 @@ local function loadStorybookModule(module: ModuleScript, providedLoader: ModuleL
 
 	assert(wasRequired, `failed to load storybook {module:GetFullName()}: {result}`)
 
+	do -- Roblox internal. This behavior may be removed without notice.
+		if not result.storyRoots and result.storyRoot then
+			-- Some storybooks use `storyRoot: Instance` instead of a
+			-- `storyRoots` array.
+			result.storyRoots = { result.storyRoot }
+			result.storyRoot = nil
+		end
+	end
+
 	local isStorybook, message = types.IStorybook(result)
 
 	assert(isStorybook, `failed to load storybook {module:GetFullName()}: {message}`)

--- a/src/loadStorybookModule.spec.luau
+++ b/src/loadStorybookModule.spec.luau
@@ -117,3 +117,17 @@ describe("legacy support", function()
 		})
 	end)
 end)
+
+describe("roblox internal", function()
+	test("map storyRoot (single instance) to storyRoots (array of instances)", function()
+		local storybookModule = createMockStorybookModule([[
+			return {
+				storyRoot = Instance.new("Folder"),
+			}
+		]])
+
+		local storybook = loadStorybookModule(storybookModule)
+
+		expect(#storybook.storyRoots).toBe(1)
+	end)
+end)


### PR DESCRIPTION
# Problem

Roblox storybooks use `storyRoot` (singular) so we need to map that over to `storyRoots` that Storyteller expects

# Solution

Super simple

Split from #29
