### PR TITLE
Storybook groups

### DIFF
--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -47,6 +47,12 @@ local function loadStorybookModule(module: ModuleScript, providedLoader: ModuleL
 		end
 	end
 
+	do -- Roblox internal. This behavior may be removed without notice.
+		if result.group then
+			result.name = `{result.group} / {result.name}`
+		end
+	end
+
 	result.source = module
 	result.loader = loader
 


### PR DESCRIPTION
# Problem

Roblox's internal story format has a `group` property on storybooks to provide a basic way to group storybooks together

# Solution

In Developer Storybook, the storybooks that are grouped together are placed under a folder in the sidebar. In our case, we're just appending the group to the name. Flipbook sorts alphabetically so this is good enough
