### PR TITLE
Naive substory support

### DIFF
--- a/src/loadStoryModule.luau
+++ b/src/loadStoryModule.luau
@@ -48,6 +48,26 @@ local function loadStoryModule<T>(storyModule: ModuleScript, storybook: LoadedSt
 		}
 	end
 
+	do
+		-- Roblox internal. This behavior may be substantially changed or
+		-- removed in the future. We need support for substories to be
+		-- compatible with Developer Storybook, so we're just selecting a
+		-- randomly accessed one but ideally we should be able to render them
+		-- all out
+		if result.stories and not result.story then
+			local randomSubstory
+			for _, substory in result.stories do
+				randomSubstory = substory
+				break
+			end
+			if typeof(randomSubstory) == "table" then
+				result.story = randomSubstory.story
+			else
+				result.story = randomSubstory
+			end
+		end
+	end
+
 	local isValid, message = types.IStory(result)
 
 	if not isValid then

--- a/src/loadStoryModule.spec.luau
+++ b/src/loadStoryModule.spec.luau
@@ -218,3 +218,30 @@ describe("legacy support", function()
 		})
 	end)
 end)
+
+describe("roblox internal", function()
+	test("pick a single substory to show", function()
+		local storybook: types.LoadedStorybook = {
+			name = "Storybook",
+			storyRoots = {},
+			loader = ModuleLoader.new(),
+			source = Instance.new("ModuleScript"),
+			packages = {},
+		}
+
+		local storyModule = createMockStoryModule([[
+			return {
+				stories = {
+					One = function() end,
+					Two = function() end,
+					Three = function() end,
+				}
+			}
+		]])
+
+		local story = loadStoryModule(storyModule, storybook)
+
+		expect(story.story).toBeDefined()
+		expect((story :: any).substories).toBeUndefined()
+	end)
+end)


### PR DESCRIPTION
# Problem

Developer Storybook supports a `stories` array to include many stories to render from a single story module

# Solution

We're taking a non-committal approach by selecting a random story from the `stories` array to render out.

This is definitely going to lead to some confusion when using Flipbook at Roblox but I just want to at least ensure stories won't blow up while I work out if we want this included permanently

Split from #29
