### PR TITLE
Static props

### DIFF
--- a/src/render.luau
+++ b/src/render.luau
@@ -79,11 +79,11 @@ local function render<T>(container: Instance, story: LoadedStory<T>): RenderLife
 	local prevProps: StoryProps?
 
 	local function renderOnce(controls: StoryControls?)
-		local props: StoryProps = {
+		local props: StoryProps = Sift.Dictionary.join(story.props or {}, {
 			container = container,
 			story = story,
 			theme = "Dark", -- TODO: Support theme changing
-		}
+		})
 
 		props.controls = Sift.Dictionary.join(
 			if story.controls then collapseControls(story.controls) else nil,

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -1,6 +1,8 @@
 local types = require("@root/types")
 
 type StoryRenderer<T> = types.StoryRenderer<T>
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 type Packages = {
 	React: any,
@@ -14,14 +16,14 @@ local function isReactElement(maybeElement: any): boolean
 	return false
 end
 
-local function createReactRenderer(packages: Packages): StoryRenderer<unknown>
+local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 	local React = packages.React
 	local ReactRoblox = packages.ReactRoblox
 
 	local root
 	local currentStory
 
-	local function reactRender(story: types.LoadedStory<unknown>, props)
+	local function reactRender(story: types.LoadedStory<unknown>, props: StoryProps)
 		local element
 		if isReactElement(story.story) then
 			element = story.story
@@ -33,12 +35,12 @@ local function createReactRenderer(packages: Packages): StoryRenderer<unknown>
 		root:render(element)
 	end
 
-	local function mount(container, story, props)
+	local function mount(container: Instance, story: LoadedStory<T>, props: StoryProps)
 		root = ReactRoblox.createRoot(container)
 		reactRender(story, props)
 	end
 
-	local function update(props)
+	local function update(props: StoryProps)
 		if currentStory then
 			reactRender(currentStory, props)
 		end

--- a/src/renderers/createRoactRenderer.luau
+++ b/src/renderers/createRoactRenderer.luau
@@ -1,6 +1,8 @@
 local types = require("@root/types")
 
 type StoryRenderer<T> = types.StoryRenderer<T>
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 type Packages = {
 	Roact: any,
@@ -13,16 +15,16 @@ local function isRoactElement(maybeElement: any): boolean
 	return false
 end
 
-local function createRoactRenderer(packages: Packages): StoryRenderer<unknown>
+local function createRoactRenderer<T>(packages: Packages): StoryRenderer<T>
 	local Roact = packages.Roact
 	local tree
 	local currentComponent
 
-	local function mount(container, story, props)
+	local function mount(container: Instance, story: LoadedStory<T>, props: StoryProps)
 		local element
 
 		if isRoactElement(story.story) then
-			currentComponent = story.story.component
+			currentComponent = (story.story :: any).component
 			element = story.story
 		else
 			currentComponent = story.story
@@ -32,7 +34,7 @@ local function createRoactRenderer(packages: Packages): StoryRenderer<unknown>
 		tree = Roact.mount(element, container, "RoactRenderer")
 	end
 
-	local function update(props)
+	local function update(props: StoryProps)
 		if tree and currentComponent then
 			local element = Roact.createElement(currentComponent, props)
 			Roact.update(tree, element)

--- a/src/types.luau
+++ b/src/types.luau
@@ -67,6 +67,8 @@ export type Story<T> = {
 	name: string?,
 	packages: StoryPackages?,
 	summary: string?,
+	-- TODO: Double check if Developer Storybook lets you do this
+	props: { [string]: any }?,
 }
 types.IStory = t.interface({
 	story = t.any,
@@ -85,6 +87,7 @@ export type LoadedStory<T> = {
 
 	summary: string?,
 	controls: StoryControls?,
+	props: { [string]: any }?,
 }
 
 return types


### PR DESCRIPTION
# Problem


Developer Storybook supports a static `props` object on the story definition. This gets merged with StoryProps and sent down to the story. This is kind of like supplying controls that don't change.

# Solution

Implemented a `props` object that can optionally be passed to the story definition

Split from #29