### PR TITLE
Provide names to our control types

### DIFF
--- a/src/controls/ControlTypes.luau
+++ b/src/controls/ControlTypes.luau
@@ -21,14 +21,18 @@ local StoryControlValue: StoryControlValue = gt.union(
 )
 export.StoryControlValue = gt.build(StoryControlValue)
 
-local function BaseControl<T>(controlType: ControlType, valueType: T)
-	return gt.struct({
+local function BaseControl<T>(name: string, controlType: ControlType, valueType: T)
+	local control = gt.struct({
 		type = gt.literal(controlType) :: ControlType,
 		default = gt.optional(valueType),
 	})
+
+	return gt.withCustom(control, function()
+		return true
+	end, name)
 end
 
-local function BaseNumberControl(controlType: ControlType)
+local function BaseNumberControl(name: string, controlType: ControlType)
 	local control = gt.struct({
 		type = gt.literal(controlType) :: ControlType,
 		default = gt.optional(gt.number()),
@@ -47,7 +51,8 @@ local function BaseNumberControl(controlType: ControlType)
 				end
 			end
 			return true, nil
-		end
+		end,
+		name
 	)
 end
 
@@ -60,7 +65,7 @@ local SelectOneOptions = gt.struct({
 	sort = gt.optional(SortFn),
 })
 
-local function SelectOneControl(controlType: ControlType)
+local function SelectOneControl(name: string, controlType: ControlType)
 	local control = gt.intersection(
 		gt.struct({
 			type = gt.literal(controlType) :: ControlType,
@@ -75,7 +80,7 @@ local function SelectOneControl(controlType: ControlType)
 		end
 
 		return true, nil
-	end)
+	end, name)
 end
 
 local SelectManyOptions = gt.struct({
@@ -84,7 +89,7 @@ local SelectManyOptions = gt.struct({
 	sort = gt.optional(SortFn),
 })
 
-local function SelectManyControl(controlType: ControlType)
+local function SelectManyControl(name: string, controlType: ControlType)
 	local control = gt.intersection(
 		gt.struct({
 			type = gt.literal(controlType) :: ControlType,
@@ -103,31 +108,31 @@ local function SelectManyControl(controlType: ControlType)
 		end
 
 		return true, nil
-	end)
+	end, name)
 end
 
-local BooleanControl = BaseControl(ControlType.Boolean, gt.boolean())
+local BooleanControl = BaseControl("BooleanControl", ControlType.Boolean, gt.boolean())
 export.BooleanControl = gt.build(BooleanControl)
 export type BooleanControl = typeof(BooleanControl)
 
-local StringControl = BaseControl(ControlType.String, gt.string())
+local StringControl = BaseControl("StringControl", ControlType.String, gt.string())
 export.StringControl = gt.build(StringControl)
 export type StringControl = typeof(StringControl)
 
-local NumberControl = BaseNumberControl(ControlType.Number)
+local NumberControl = BaseNumberControl("NumberControl", ControlType.Number)
 export.NumberControl = gt.build(NumberControl)
 export type NumberControl = typeof(NumberControl)
 
-local SliderControl = BaseNumberControl(ControlType.Slider)
+local SliderControl = BaseNumberControl("SliderControl", ControlType.Slider)
 export.SliderControl = gt.build(SliderControl)
 export type SliderControl = typeof(SliderControl)
 
-local ColorControl = BaseControl(ControlType.Color, gt.Color3())
+local ColorControl = BaseControl("ColorControl", ControlType.Color, gt.Color3())
 export.ColorControl = gt.build(ColorControl)
 export type ColorControl = typeof(ColorControl)
 export type ColourControl = ColorControl
 
-local DateControl = BaseControl(ControlType.Date, gt.isTypeof("DateTime"))
+local DateControl = BaseControl("DateControl", ControlType.Date, gt.isTypeof("DateTime"))
 export.DateControl = gt.build(DateControl)
 export type DateControl = typeof(DateControl)
 
@@ -135,7 +140,7 @@ local SelectOptions = SelectOneOptions
 export.SelectOptions = gt.build(SelectOptions)
 export type SelectOptions = typeof(SelectOptions)
 
-local SelectControl = SelectOneControl(ControlType.Select)
+local SelectControl = SelectOneControl("SelectControl", ControlType.Select)
 export.SelectControl = gt.build(SelectControl)
 export type SelectControl = typeof(SelectControl)
 
@@ -143,7 +148,7 @@ local RadioOptions = SelectOneOptions
 export.RadioOptions = gt.build(RadioOptions)
 export type RadioOptions = typeof(RadioOptions)
 
-local RadioControl = SelectOneControl(ControlType.Radio)
+local RadioControl = SelectOneControl("RadioControl", ControlType.Radio)
 export.RadioControl = gt.build(RadioControl)
 export type RadioControl = typeof(RadioControl)
 
@@ -151,7 +156,8 @@ local MultiSelectOptions = SelectManyOptions
 export.MultiSelectOptions = gt.build(MultiSelectOptions)
 export type MultiSelectOptions = typeof(MultiSelectOptions)
 
-local MultiSelectControl = gt.intersection(SelectManyControl(ControlType.MultiSelect), MultiSelectOptions)
+local MultiSelectControl =
+	gt.intersection(SelectManyControl("MultiSelectControl", ControlType.MultiSelect), MultiSelectOptions)
 export.MultiSelectControl = gt.build(MultiSelectControl)
 export type MultiSelectControl = typeof(MultiSelectControl)
 
@@ -159,7 +165,7 @@ local CheckOptions = SelectManyOptions
 export.CheckOptions = gt.build(CheckOptions)
 export type CheckOptions = typeof(CheckOptions)
 
-local CheckControl = SelectManyControl(ControlType.Check)
+local CheckControl = SelectManyControl("CheckControl", ControlType.Check)
 export.CheckControl = gt.build(CheckControl)
 export type CheckControl = typeof(CheckControl)
 

--- a/src/controls/ControlTypes.luau
+++ b/src/controls/ControlTypes.luau
@@ -182,7 +182,7 @@ local AdvancedStoryControl = gt.union(SliderControl, ListBasedStoryControl)
 export.AdvancedStoryControl = gt.build(AdvancedStoryControl)
 export type AdvancedStoryControl = typeof(AdvancedStoryControl)
 
-local ObjectControl = BaseControl(ControlType.Object, gt.Instance())
+local ObjectControl = BaseControl("ObjectControl", ControlType.Object, gt.Instance())
 export.ObjectControl = gt.build(ObjectControl)
 export type ObjectControl = typeof(ObjectControl)
 


### PR DESCRIPTION
# Problem

Our error messages relating to controls are incredibly unwieldy and downright useless to the average user.

# Solution

One aspect we can improve on is the type names. By default GreenTea propagates these with the path to ControlTypes. Custom controls have the option to provide a name though, so I've switched us over to that and things are already a lot more legible. Here's the before and after:

Before:

```
PluginDebugService.user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.migrateControlsSchema:53: failed to parse controls schema (schema doesn't match a known format and couldn't be migrated)
err: expected table
{
    [string]:
    (({ default: string?, type: "String" }    
        | { default: boolean?, type: "Boolean" }
        | {
                step: number?,
                type: "Number",
                range: NumberRange?,
                default: number?
            } & custom<user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.ControlTypes:42>)    
        | ({
                step: number?,
                type: "Slider",
                range: NumberRange?,
                default: number?
            } & custom<user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.ControlTypes:42>    
            | ({
                    items: {
                        @array,
                        boolean | number | string | Color3 | DateTime | EnumItem
                    },
                    type: "Select"
                }    
                    & {
                        tostring: (<cyclic>) -> string?,
                        default: (<cyclic>)?,
                        sort: (<cyclic>, <cyclic>) -> boolean?
                    } & custom<user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.ControlTypes:72>    
                | ({ items: { @array, <cyclic> }, type: "MultiSelect" }    
                        & {
                            tostring: <cyclic>?,
                            default: { @array, <cyclic> }?,
                            sort: <cyclic>?
                        } & custom<user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.ControlTypes:96>    
                    & <cyclic>)
                | { items: { @array, <cyclic> }, type: "Check" } & <cyclic> & custom<user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.ControlTypes:96>
                | { items: { @array, <cyclic> }, type: "Radio" } & <cyclic> & custom<user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.ControlTypes:72>))
        | ({ default: Color3?, type: "Color" }    
            | { default: DateTime?, type: "Date" }))    
        | (<cyclic>)
}
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
expected table
```

After:

```
PluginDebugService.user_Flipbook.rbxm.Flipbook.Packages._Index.flipbook-labs_storyteller@1.10.0.storyteller.controls.migrateControlsSchema:53: failed to parse controls schema (schema doesn't match a known format and couldn't be migrated)
err: expected table
{
    [string]:
    (({ default: string?, type: "String" } & custom<StringControl>    
        | { default: boolean?, type: "Boolean" } & custom<BooleanControl>
        | {
                step: number?,
                type: "Number",
                range: NumberRange?,
                default: number?
            } & custom<NumberControl>)    
        | ({
                step: number?,
                type: "Slider",
                range: NumberRange?,
                default: number?
            } & custom<SliderControl>    
            | ({
                    items: {
                        @array,
                        boolean | number | string | Color3 | DateTime | EnumItem
                    },
                    type: "Select"
                }    
                    & {
                        tostring: (<cyclic>) -> string?,
                        default: (<cyclic>)?,
                        sort: (<cyclic>, <cyclic>) -> boolean?
                    } & custom<SelectControl>    
                | ({ items: { @array, <cyclic> }, type: "MultiSelect" }    
                        & {
                            tostring: <cyclic>?,
                            default: { @array, <cyclic> }?,
                            sort: <cyclic>?
                        } & custom<MultiSelectControl>    
                    & <cyclic>)
                | { items: { @array, <cyclic> }, type: "Check" } & <cyclic> & custom<CheckControl>
                | { items: { @array, <cyclic> }, type: "Radio" } & <cyclic> & custom<RadioControl>))
        | ({ default: Color3?, type: "Color" } & custom<ColorControl>    
            | { default: DateTime?, type: "Date" } & custom<DateControl>))    
        | (<cyclic>)
}
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
expected table
```

This will resolve https://github.com/flipbook-labs/flipbook/issues/574 once downstreamed
