### PR TITLE
UI Labs compat tweaks

### DIFF
--- a/src/controls/migrations/ui-labs-v2.4.2/migrateUILabsControl.luau
+++ b/src/controls/migrations/ui-labs-v2.4.2/migrateUILabsControl.luau
@@ -7,6 +7,7 @@ local UILabsTypes = require("@root/controls/migrations/ui-labs-v2.4.2/UILabsType
 type UILabsControl = UILabsTypes.Control
 
 type StoryControl = ControlTypes.StoryControl
+type StoryControlValue = ControlTypes.StoryControlValue
 type StringControl = ControlTypes.StringControl
 type NumberControl = ControlTypes.NumberControl
 type BooleanControl = ControlTypes.BooleanControl
@@ -38,15 +39,15 @@ local function migrateUILabsControl(control: UILabsControl): StoryControl?
 	elseif control.Type == "Choose" then
 		local migrated: SelectControl = {
 			type = ControlType.Select,
-			items = Sift.List.map(control.List, tostring),
-			default = tostring(control.List[control.DefIndex]),
+			items = control.List :: { StoryControlValue },
+			default = control.List[control.DefIndex] :: StoryControlValue,
 		}
 		return migrated
 	elseif control.Type == "EnumList" then
 		local migrated: SelectControl = {
 			type = ControlType.Select,
-			items = Sift.List.sort(Sift.Dictionary.values(control.List)),
-			default = control.List[control.DefIndex],
+			items = Sift.List.sort(Sift.Dictionary.keys(control.List)),
+			default = control.DefIndex,
 		}
 		return migrated
 	elseif control.Type == "Slider" then

--- a/src/controls/migrations/ui-labs-v2.4.2/migrateUILabsControl.spec.luau
+++ b/src/controls/migrations/ui-labs-v2.4.2/migrateUILabsControl.spec.luau
@@ -95,10 +95,20 @@ describe("UILabs.Choose", function()
 			default = "Option 2",
 		})
 	end)
+
+	test("preserves non-string item types", function()
+		local control = UILabs.Choose({ 10, 20, 30 })
+
+		expect(migrateUILabsControl(control :: any)).toMatchObject({
+			type = ControlType.Select,
+			items = { 10, 20, 30 },
+			default = 10,
+		})
+	end)
 end)
 
 describe("UILabs.EnumList", function()
-	test("maps to ControlType.Select", function()
+	test("uses keys as items and the default key as default", function()
 		local control = (
 			UILabs.EnumList({
 				Option1 = "Option 1",
@@ -110,11 +120,31 @@ describe("UILabs.EnumList", function()
 		expect(migrateUILabsControl(control)).toMatchObject({
 			type = ControlType.Select,
 			items = {
-				"Option 1",
-				"Option 2",
-				"Option 3",
+				"Option1",
+				"Option2",
+				"Option3",
 			},
-			default = "Option 1",
+			default = "Option1",
+		})
+	end)
+
+	test("works when values are non-string types", function()
+		local control = (
+			UILabs.EnumList({
+				Mobile = 500,
+				Tablet = 1000,
+				Desktop = 1500,
+			}, "Mobile") :: any
+		) :: UILabsControl
+
+		expect(migrateUILabsControl(control)).toMatchObject({
+			type = ControlType.Select,
+			items = {
+				"Desktop",
+				"Mobile",
+				"Tablet",
+			},
+			default = "Mobile",
 		})
 	end)
 end)


### PR DESCRIPTION
# Problem

Our UI Labs migration has a couple bugs in how we convert `Choose` and `EnumList` controls:
1. `Choose`: All items and the default are implicitly tostring'd, silently losing type information
2. `EnumList`: The items are mapped from the dictionary's values but it should instead map to the keys

# Solution

Updated both control migrations so `Choose` will pass its items through without using tostring and EnumList now resolves its items based on the dict keys
