### PR TITLE
Object control type

### DIFF
--- a/src/controls/ControlTypes.luau
+++ b/src/controls/ControlTypes.luau
@@ -7,7 +7,7 @@ local export = {}
 export type ControlType = ControlType.ControlType
 
 -- Make sure to update this when adding new control types!
-export type StoryControlValue = boolean | number | string | Color3 | DateTime | EnumItem
+export type StoryControlValue = boolean | number | string | Color3 | DateTime | EnumItem | Instance
 local StoryControlValue: StoryControlValue = gt.union(
 	-- Primitives
 	gt.boolean() :: StoryControlValue,
@@ -17,7 +17,8 @@ local StoryControlValue: StoryControlValue = gt.union(
 	-- Roblox datatypes
 	gt.Color3(),
 	gt.isTypeof("DateTime"),
-	gt.isTypeof("EnumItem")
+	gt.isTypeof("EnumItem"),
+	gt.Instance()
 )
 export.StoryControlValue = gt.build(StoryControlValue)
 
@@ -175,7 +176,11 @@ local AdvancedStoryControl = gt.union(SliderControl, ListBasedStoryControl)
 export.AdvancedStoryControl = gt.build(AdvancedStoryControl)
 export type AdvancedStoryControl = typeof(AdvancedStoryControl)
 
-local RobloxStoryControl = gt.union(ColorControl, DateControl)
+local ObjectControl = BaseControl(ControlType.Object, gt.Instance())
+export.ObjectControl = gt.build(ObjectControl)
+export type ObjectControl = typeof(ObjectControl)
+
+local RobloxStoryControl = gt.union(ColorControl, DateControl, ObjectControl)
 export.RobloxStoryControl = gt.build(RobloxStoryControl)
 export type RobloxStoryControl = typeof(RobloxStoryControl)
 

--- a/src/controls/constructors/createObjectControl.luau
+++ b/src/controls/constructors/createObjectControl.luau
@@ -1,0 +1,17 @@
+local ControlType = require("@root/controls/enums/ControlType")
+local ControlTypes = require("@root/controls/ControlTypes")
+
+type ObjectControl = ControlTypes.ObjectControl
+
+local function createObjectControl(default: Instance?): ObjectControl
+	local control: ObjectControl = {
+		type = ControlType.Object,
+		default = default,
+	}
+
+	ControlTypes.ObjectControl:assert(control)
+
+	return control
+end
+
+return createObjectControl

--- a/src/controls/constructors/createObjectControl.spec.luau
+++ b/src/controls/constructors/createObjectControl.spec.luau
@@ -1,0 +1,18 @@
+local JestGlobals = require("@pkg/JestGlobals")
+
+local createObjectControl = require("./createObjectControl")
+
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+test("creates a control with no default", function()
+	expect(function()
+		createObjectControl()
+	end).never.toThrow()
+end)
+
+test("creates a control with an Instance default", function()
+	expect(function()
+		createObjectControl(game)
+	end).never.toThrow()
+end)

--- a/src/controls/enums/ControlType.luau
+++ b/src/controls/enums/ControlType.luau
@@ -8,6 +8,7 @@ export type ControlType =
 	| "Color"
 	| "Date"
 	| "MultiSelect"
+	| "Object"
 	| "Radio"
 	| "Select"
 	| "Slider"
@@ -23,6 +24,7 @@ local ControlType = {
 	Color = "Color" :: "Color",
 	Date = "Date" :: "Date",
 	MultiSelect = "MultiSelect" :: "MultiSelect",
+	Object = "Object" :: "Object",
 	Radio = "Radio" :: "Radio",
 	Select = "Select" :: "Select",
 	Slider = "Slider" :: "Slider",

--- a/src/controls/hydrateControls.spec.luau
+++ b/src/controls/hydrateControls.spec.luau
@@ -58,6 +58,9 @@ test("hydrates a schema using all control types", function()
 		date = {
 			type = ControlType.Date,
 		},
+		object = {
+			type = ControlType.Object,
+		},
 		-- List-based
 		dropdown = {
 			type = ControlType.Select,
@@ -194,6 +197,10 @@ test("default value is used when one is not supplied", function()
 			type = ControlType.Date,
 			default = DateTime.now(),
 		},
+		object = {
+			type = ControlType.Object,
+			default = game,
+		},
 		-- List-based
 		dropdown = {
 			type = ControlType.Select,
@@ -251,6 +258,7 @@ test("default value is used when one is not supplied", function()
 		slider = 1,
 		color = expect.any("Color3"),
 		date = expect.any("DateTime"),
+		object = game,
 		dropdown = "Option 1",
 		multiSelect = {
 			"Option 1",

--- a/src/init.luau
+++ b/src/init.luau
@@ -35,6 +35,7 @@ export type ControlType = ControlTypes.ControlType
 export type DateControl = ControlTypes.DateControl
 export type MultiSelectControl = ControlTypes.MultiSelectControl
 export type NumberControl = ControlTypes.NumberControl
+export type ObjectControl = ControlTypes.ObjectControl
 export type RadioControl = ControlTypes.RadioControl
 export type SelectControl = ControlTypes.SelectControl
 export type SliderControl = ControlTypes.SliderControl
@@ -78,6 +79,7 @@ return {
 	createDateControl = require("@self/controls/constructors/createDateControl"),
 	createMultiSelectControl = require("@self/controls/constructors/createMultiSelectControl"),
 	createNumberControl = require("@self/controls/constructors/createNumberControl"),
+	createObjectControl = require("@self/controls/constructors/createObjectControl"),
 	createRadioControl = require("@self/controls/constructors/createRadioControl"),
 	createSelectControl = require("@self/controls/constructors/createSelectControl"),
 	createSliderControl = require("@self/controls/constructors/createSliderControl"),


### PR DESCRIPTION
# Problem

Flipbook wants an Instance selector control type for linking stories with Instances in the DataModel. This is also a feature UI Labs includes that we'd like to mirror.

# Solution

Introduced the scaffolding for an Object control type. 

This will later be used by Flipbook to render out an Instance selector
