### PR TITLE
Bump FlipbookBatteries and Lute versions

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -7,6 +7,6 @@
 		"pkg": "./Packages",
 		"repo": ".",
 		"root": "./src",
-		"batteries": "~/.loom/store/Lute@v1.0.1-nightly.20260508/batteries"
+		"batteries": "~/.loom/store/Lute@v1.0.1-nightly.20260612/batteries"
 	}
 }

--- a/.lute/analyze.luau
+++ b/.lute/analyze.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 local cli = require("@batteries/cli")
 local path = require("@std/path")
 local system = require("@std/system")

--- a/.lute/build.luau
+++ b/.lute/build.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 local cli = require("@batteries/cli")
 local fs = require("@std/fs")
 local process = require("@std/process")

--- a/.lute/install.luau
+++ b/.lute/install.luau
@@ -36,7 +36,7 @@ do
 end
 
 do
-	local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+	local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 
 	local run = FlipbookBatteries.run
 	local find = FlipbookBatteries.find

--- a/.lute/lint.luau
+++ b/.lute/lint.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 local fs = require("@std/fs")
 local process = require("@std/process")
 

--- a/.lute/serve-docs.luau
+++ b/.lute/serve-docs.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 
 local run = FlipbookBatteries.run
 

--- a/.lute/test.luau
+++ b/.lute/test.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 local cli = require("@batteries/cli")
 local path = require("@std/path")
 local process = require("@std/process")

--- a/.lute/try-in-flipbook.luau
+++ b/.lute/try-in-flipbook.luau
@@ -4,7 +4,7 @@
 	path/git dependencies, so we have to make our own shim.
 ]]
 
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.10.1")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
 local fs = require("@std/fs")
 local path = require("@std/path")
 

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -4,12 +4,12 @@ return {
 		version = "1.10.0",
 		dependencies = {
 			FlipbookBatteries = {
-				rev = "v0.10.1",
+				rev = "v0.11.0",
 				sourceKind = "github",
 				source = "https://github.com/flipbook-labs/flipbook-batteries",
 			},
 			Lute = {
-				rev = "v1.0.1-nightly.20260508",
+				rev = "v1.0.1-nightly.20260612",
 				sourceKind = "github",
 				source = "https://github.com/luau-lang/lute",
 			},

--- a/rokit.toml
+++ b/rokit.toml
@@ -7,7 +7,7 @@
 darklua = "seaofvoices/darklua@0.17.3"
 git-cliff = "orhun/git-cliff@2.13.1"
 luau-lsp = "JohnnyMorganz/luau-lsp@1.59.0"
-lute = "luau-lang/lute@1.0.1-nightly.20260508"
+lute = "luau-lang/lute@1.0.1-nightly.20260612"
 rocale = "Roblox/rocale-cli@0.1.0"
 rojo = "rojo-rbx/rojo@7.6.1"
 selene = "Kampfkarren/selene@0.29.0"


### PR DESCRIPTION
Upgrades FlipbookBatteries from v0.10.1 to v0.11.0 and Lute from nightly.20260508 to nightly.20260612, matching the versions FlipbookBatteries uses.

Changes `loom.config.luau` and `rokit.toml` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)