### PR TITLE
Add mapStory support to all renderers

### DIFF
--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -39,13 +39,21 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 	end
 
 	local function mount(container: Instance, story: LoadedStory<Instance>, props: StoryProps)
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+
 		props = transformProps(props)
 		prevProps = props
 
 		if typeof(story.story) == "Instance" then
 			handle = story.story
 		elseif typeof(story.story) == "function" then
-			handle = story.story(props)
+			local storyFn = story.story
+
+			if mapStory then
+				storyFn = mapStory(story.story)
+			end
+
+			handle = storyFn(props)
 		end
 
 		if handle then

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -121,6 +121,25 @@ describe("Fusion 0.3.0", function()
 
 		expect(element.Text).toBe("Enabled")
 	end)
+
+	test("mapStory wraps the story", function()
+		local story = createFusionStory(TextStory)
+
+		story.storybook.mapStory = function(element)
+			return function(props)
+				local frame = scope:New("Frame")({})
+				local inner = element(props)
+				inner.Parent = frame
+				return frame
+			end
+		end
+
+		render(container, story)
+
+		local frame = container:FindFirstChildWhichIsA("Frame") :: Frame
+		expect(frame).toBeDefined()
+		expect(frame:FindFirstChildWhichIsA("TextLabel")).toBeDefined()
+	end)
 end)
 
 describe("Fusion 0.2.0", function()
@@ -221,5 +240,25 @@ describe("Fusion 0.2.0", function()
 		task.wait()
 
 		expect(element.Text).toBe("Enabled")
+	end)
+
+	test("mapStory wraps the story", function()
+		local story = createFusionStory(TextStory)
+
+		story.storybook.mapStory = function(element)
+			return function(props)
+				local frame = New("Frame")({})
+				local inner = element(props)
+				inner.Parent = frame
+				return frame
+			end
+		end
+
+		render(container, story)
+
+		local frame = container:FindFirstChildWhichIsA("Frame")
+		expect(frame).toBeDefined()
+		assert(frame, "no frame found")
+		expect(frame:FindFirstChildWhichIsA("TextLabel")).toBeDefined()
 	end)
 end)

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -256,9 +256,8 @@ describe("Fusion 0.2.0", function()
 
 		render(container, story)
 
-		local frame = container:FindFirstChildWhichIsA("Frame")
+		local frame = container:FindFirstChildWhichIsA("Frame") :: Frame
 		expect(frame).toBeDefined()
-		assert(frame, "no frame found")
 		expect(frame:FindFirstChildWhichIsA("TextLabel")).toBeDefined()
 	end)
 end)

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -21,10 +21,15 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		if typeof(story.story) == "Instance" then
 			result = story.story
 		elseif typeof(story.story) == "function" then
-			if debug.info(story.story, "a") >= 2 then
-				result = (story :: any).story(container, props)
+			local mapStory = if story.storybook then story.storybook.mapStory else nil
+
+			if mapStory then
+				local storyFn = mapStory(story.story)
+				result = storyFn(props)
+			elseif debug.info(story.story, "a") >= 2 then
+				result = story.story(container, props)
 			else
-				result = (story :: any).story(props)
+				result = story.story(props)
 			end
 		end
 

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -125,6 +125,30 @@ test("update the GuiObject on arg changes", function()
 	expect(button.Text).toBe("Enabled")
 end)
 
+test("mapStory wraps the story", function()
+	local story = createStory({
+		story = function(_props)
+			local label = Instance.new("TextLabel")
+			return label
+		end,
+	})
+
+	story.storybook.mapStory = function(element)
+		return function(props)
+			local frame = Instance.new("Frame")
+			local inner = element(props)
+			inner.Parent = frame
+			return frame
+		end
+	end
+
+	render(container, story)
+
+	local frame = container:FindFirstChildWhichIsA("Frame") :: Frame
+	expect(frame).toBeDefined()
+	expect(frame:FindFirstChildWhichIsA("TextLabel")).toBeDefined()
+end)
+
 test("lifecycle", function()
 	expect(#container:GetChildren()).toBe(0)
 


### PR DESCRIPTION
## Problem

`mapStory` was already wired up in the React and Roact renderers but wasn't supported in Fusion or the Manual renderer.

## Solution

Add `mapStory` handling to `createFusionRenderer` and `createManualRenderer`, following the same pattern already used by React/Roact: read `story.storybook.mapStory` at mount time and, when present, wrap the story function before calling it. Each renderer also gets a corresponding spec test.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)