### PR TITLE
Upgrade FlipbookBatteries to v0.12.0, Lute to nightly.20260701, and align toolchain

### DIFF
--- a/.changes/upgrade-lute-and-batteries.md
+++ b/.changes/upgrade-lute-and-batteries.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Dependencies
+---
+
+Upgrade FlipbookBatteries `v0.11.0` → `v0.12.0` and Lute `v1.0.1-nightly.20260612` → `v1.0.1-nightly.20260701`, and align the toolchain (luau-lsp `1.68.1`, selene `0.31.0`, StyLua `2.5.2`, rocale-cli `0.1.3`, wally-package-types `1.6.2`).

--- a/.luaurc
+++ b/.luaurc
@@ -7,6 +7,6 @@
 		"pkg": "./Packages",
 		"repo": ".",
 		"root": "./src",
-		"batteries": "~/.loom/store/Lute@v1.0.1-nightly.20260612/batteries"
+		"batteries": "~/.loom/store/Lute@v1.0.1-nightly.20260701/batteries"
 	}
 }

--- a/.lute/analyze.luau
+++ b/.lute/analyze.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 local cli = require("@batteries/cli")
 local path = require("@std/path")
 local system = require("@std/system")

--- a/.lute/build.luau
+++ b/.lute/build.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 local cli = require("@batteries/cli")
 local fs = require("@std/fs")
 local process = require("@std/process")

--- a/.lute/install.luau
+++ b/.lute/install.luau
@@ -36,7 +36,7 @@ do
 end
 
 do
-	local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+	local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 
 	local run = FlipbookBatteries.run
 	local find = FlipbookBatteries.find

--- a/.lute/lint.luau
+++ b/.lute/lint.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 local fs = require("@std/fs")
 local process = require("@std/process")
 

--- a/.lute/serve-docs.luau
+++ b/.lute/serve-docs.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 
 local run = FlipbookBatteries.run
 

--- a/.lute/test.luau
+++ b/.lute/test.luau
@@ -1,4 +1,4 @@
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 local cli = require("@batteries/cli")
 local path = require("@std/path")
 local process = require("@std/process")

--- a/.lute/try-in-flipbook.luau
+++ b/.lute/try-in-flipbook.luau
@@ -4,7 +4,7 @@
 	path/git dependencies, so we have to make our own shim.
 ]]
 
-local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.11.0")
+local FlipbookBatteries = require("@luaupkg/FlipbookBatteries@v0.12.0")
 local fs = require("@std/fs")
 local path = require("@std/path")
 

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -4,12 +4,12 @@ return {
 		version = "1.12.0",
 		dependencies = {
 			FlipbookBatteries = {
-				rev = "v0.11.0",
+				rev = "v0.12.0",
 				sourceKind = "github",
 				source = "https://github.com/flipbook-labs/flipbook-batteries",
 			},
 			Lute = {
-				rev = "v1.0.1-nightly.20260612",
+				rev = "v1.0.1-nightly.20260701",
 				sourceKind = "github",
 				source = "https://github.com/luau-lang/lute",
 			},

--- a/rokit.toml
+++ b/rokit.toml
@@ -5,11 +5,11 @@
 
 [tools]
 darklua = "seaofvoices/darklua@0.19.0"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.59.0"
-lute = "luau-lang/lute@1.0.1-nightly.20260612"
-rocale = "Roblox/rocale-cli@0.1.0"
+luau-lsp = "JohnnyMorganz/luau-lsp@1.68.1"
+lute = "luau-lang/lute@1.0.1-nightly.20260701"
+rocale = "Roblox/rocale-cli@0.1.3"
 rojo = "rojo-rbx/rojo@7.6.1"
-selene = "Kampfkarren/selene@0.29.0"
-stylua = "JohnnyMorganz/StyLua@2.3.1"
+selene = "Kampfkarren/selene@0.31.0"
+stylua = "JohnnyMorganz/StyLua@2.5.2"
 wally = "UpliftGames/wally@0.3.2"
-wally-package-types = "JohnnyMorganz/wally-package-types@1.5.1"
+wally-package-types = "JohnnyMorganz/wally-package-types@1.6.2"


### PR DESCRIPTION
## Problem

`storyteller` pins FlipbookBatteries `v0.11.0` and lags badly on toolchain versions — luau-lsp `1.59.0`, selene `0.29.0`, StyLua `2.3.1`, rocale-cli `0.1.0`, wally-package-types `1.5.1`. FlipbookBatteries `v0.12.0` pins Lute `v1.0.1-nightly.20260701`, and Loom github dependencies hard-conflict on differing revs, so the direct Lute pin must move in lockstep.

## Solution

- FlipbookBatteries `v0.11.0` → `v0.12.0` and Lute `v1.0.1-nightly.20260612` → `v1.0.1-nightly.20260701`, updating every hardcoded spot: `loom.config.luau`, `rokit.toml`, the `batteries` store alias in `.luaurc`, and the `require("@luaupkg/FlipbookBatteries@…")` paths across the `.lute/` scripts.
- Align the toolchain to the fleet's highest-in-use: luau-lsp `1.68.1`, selene `0.31.0`, StyLua `2.5.2`, rocale-cli `0.1.3`, wally-package-types `1.6.2` (darklua was already `0.19.0`).
- Add a `.changes/` entry (Dependencies, patch bump).

## Verification

Local run on the new pins:

| Step | Result |
|---|---|
| `lute run install` | ✅ loom + wally + darklua patches resolve `FlipbookBatteries@v0.12.0` |
| `lute run build --channel prod` | ✅ darklua + `rojo build` produce `Storyteller.rbxm` |
| `lute run lint` | ✅ selene `0.31.0` + StyLua `2.5.2`, 0 errors / 0 warnings |
| `lute run analyze --include-build` | ✅ luau-lsp `1.68.1` across `.lute`, src, dist |
| `lute run test` | ⚠️ requires `ROBLOX_API_KEY` not available locally — CI supplies it; unrelated to this bump |

> Separate from the docs upgrade (#127) — this is the runtime/toolchain track. Part of the fleet-wide Lute `20260701` bump; depends on FlipbookBatteries `v0.12.0` (already released).

🤖 Generated with [Claude Code](https://claude.com/claude-code)