### PR TITLE
Source CI and release secrets from 1Password

### DIFF
--- a/.changes/source-ci-secrets-from-1password.md
+++ b/.changes/source-ci-secrets-from-1password.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Changes
+---
+
+CI and release workflows now source their secrets from the shared Flipbook 1Password vault at run time via `load-secrets-action` (the Roblox Open Cloud test key and the release app's private key), rather than from repo-level GitHub Actions secrets. No effect on the published package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,15 @@ jobs:
       - name: Install packages
         run: lute run install
 
+      - name: Load secrets from 1Password
+        uses: 1Password/load-secrets-action@v3
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Item "Flipbook CI (Open Cloud)" — referenced by ID because its
+          # parenthesized title breaks op:// reference parsing.
+          ROBLOX_API_KEY: op://Flipbook/7c2b4vowqat6feao5x3nm7cwom/password
+
       - name: Run tests
         run: lute run test
-        env:
-          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,21 @@ jobs:
       group: release-pr-${{ github.ref }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
+      - name: Load secrets from 1Password
+        id: op
+        uses: 1Password/load-secrets-action@v3
+        with:
+          export-env: false
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          FLIPBOOK_BACKEND_APP_PRIVATE_KEY: op://Flipbook/flipbook-backend.2025-12-13.private-key/private key
+
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.FLIPBOOK_BACKEND_APP_ID }}
-          private-key: ${{ secrets.FLIPBOOK_BACKEND_APP_PRIVATE_KEY }}
+          private-key: ${{ steps.op.outputs.FLIPBOOK_BACKEND_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

The `tests` job's `ROBLOX_API_KEY` and the `release` job's GitHub App private key are stored as repo-level GitHub Actions secrets, duplicated across flipbook-labs repos. Rotating one means editing every repo's Actions settings — no single source of truth.

## Solution

Source both from the shared **Flipbook** 1Password vault at run time via [`load-secrets-action`](https://github.com/1Password/load-secrets-action), authed by the org-level `OP_SERVICE_ACCOUNT_TOKEN`:

- **`ci.yml` `tests`** → `ROBLOX_API_KEY` from the "Flipbook CI (Open Cloud)" item. Referenced by **item ID** (`op://Flipbook/7c2b…/password`) because the item's parenthesized title breaks `op://` reference parsing.
- **`release.yml` `release`** → the GitHub App **private key** from `op://Flipbook/flipbook-backend.2025-12-13.private-key/private key`, passed to `create-github-app-token`.

Deliberately left as-is: `WALLY_REGISTRY_TOKEN` stays an org secret (team decision), and `FLIPBOOK_BACKEND_APP_ID` stays a plain input (it's a public identifier, not a secret). Once merged, the repo-level `ROBLOX_API_KEY` and `FLIPBOOK_BACKEND_APP_PRIVATE_KEY` secrets can be deleted.

## Verification

- [ ] `tests` goes green here — proves the Open Cloud key resolves and the mechanism works end-to-end on PR CI.
- [ ] Release path (app private key) only exercises on a real publish, so **watch the first release** after merge.

Part of the campaign to make 1Password the single source of truth for flipbook-labs CI secrets (follows the module-loader pilot).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)