### PR TITLE
Harden the rendering route with lifecycle specs, a mutation matrix, and middleware fixes

### DIFF
--- a/.changes/map-story-all-renderers.md
+++ b/.changes/map-story-all-renderers.md
@@ -3,4 +3,4 @@ bump: minor
 category: Fixed
 ---
 
-Apply a storybook's `mapStory` middleware in every renderer. Previously only the React and Roact renderers used it; Fusion, Vide, Iris, and manual stories ignored the middleware entirely (flipbook-labs/flipbook#552). For these renderers the mapped function `mapStory(story.story)` replaces the story function and is called with the story's props.
+Apply a storybook's `mapStory` middleware in every renderer. Previously only React and Roact used it — Fusion, Vide, Iris, and manual stories ignored it entirely (flipbook-labs/flipbook#552).

--- a/.changes/map-story-all-renderers.md
+++ b/.changes/map-story-all-renderers.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+category: Fixed
+---
+
+Apply a storybook's `mapStory` middleware in every renderer. Previously only the React and Roact renderers used it; Fusion, Vide, Iris, and manual stories ignored the middleware entirely (flipbook-labs/flipbook#552). For these renderers the mapped function `mapStory(story.story)` replaces the story function and is called with the story's props.

--- a/.changes/renderer-test-hardening.md
+++ b/.changes/renderer-test-hardening.md
@@ -3,4 +3,4 @@ bump: patch
 category: Fixed
 ---
 
-Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story. Previously every control change re-applied it to the already-mapped story, so a non-idempotent `mapDefinition` (one that wraps or decorates the story) would stack another transformation on each update. The Roact renderer already behaved correctly; the two now match.
+Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story, matching the Roact renderer. Previously every control change re-applied it to the already-mapped story, stacking transformations for non-idempotent middleware.

--- a/.changes/renderer-test-hardening.md
+++ b/.changes/renderer-test-hardening.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Fixed
+---
+
+Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story. Previously every control change re-applied it to the already-mapped story, so a non-idempotent `mapDefinition` (one that wraps or decorates the story) would stack another transformation on each update. The Roact renderer already behaved correctly; the two now match.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There also exist React hooks for ease of integration into storybook apps.
 ## Features
 
 * Discover Storybooks and their Story files
-* Render stories written in React, Roact, Fusion, and any generic Roblox Gui.
+* Render stories written in React, Roact, Fusion, Iris, and any generic Roblox Gui.
 
 ## Installation
 

--- a/docs/docs/contributing/story-renderers.md
+++ b/docs/docs/contributing/story-renderers.md
@@ -11,6 +11,7 @@ For each renderer, Storyteller provides a mounting point, context, and lifecycle
 | React               | Result of `React.createElement` or a function that takes `props` as the first argument and creates an element                           |
 | Roact               | Result of `Roact.createElement` or a function that takes `props` as the first argument and creates an element                           |
 | Fusion              | Result of `Fusion.New` or a function that takes `props` as the first argument and creates an Instance                                   |
+| Iris                | A function that takes `props` as the first argument and issues Iris widget calls (immediate-mode)                                       |
 | Manual              | A function that takes `props` as the first argument and returns an Instance                                                             |
 | Functional (Legacy) | A function that takes `target` as the first argument, `props` as the second, and optionally returns a function for manually cleaning up |
 | Hoarcekat (Legacy)  | Same as `Functional (Legacy)` but the story file itself is represented by a function                                                    |
@@ -139,6 +140,23 @@ return {
 	},
 	packages = {
 		Fusion = Fusion,
+	},
+}
+```
+
+### Iris
+
+```lua
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Iris = require(ReplicatedStorage.Packages.Iris)
+
+return {
+	storyRoots = {
+		script.Parent.Components,
+	},
+	packages = {
+		Iris = Iris,
 	},
 }
 ```

--- a/docs/docs/contributing/story-renderers.md
+++ b/docs/docs/contributing/story-renderers.md
@@ -11,13 +11,13 @@ For each renderer, Storyteller provides a mounting point, context, and lifecycle
 | React               | Result of `React.createElement` or a function that takes `props` as the first argument and creates an element                           |
 | Roact               | Result of `Roact.createElement` or a function that takes `props` as the first argument and creates an element                           |
 | Fusion              | Result of `Fusion.New` or a function that takes `props` as the first argument and creates an Instance                                   |
+| Vide                | A function that takes `props` as the first argument and returns an Instance, or a pre-created Instance                                  |
 | Iris                | A function that takes `props` as the first argument and issues Iris widget calls (immediate-mode)                                       |
 | Manual              | A function that takes `props` as the first argument and returns an Instance                                                             |
 | Functional (Legacy) | A function that takes `target` as the first argument, `props` as the second, and optionally returns a function for manually cleaning up |
 | Hoarcekat (Legacy)  | Same as `Functional (Legacy)` but the story file itself is represented by a function                                                    |
 
 Future:
-- [Vide](https://centau.github.io/vide/)
 - [Blend](https://quenty.github.io/NevermoreEngine/api/Blend/)
 - Developer Storybook (Roblox internal)
 
@@ -37,7 +37,7 @@ When adding a new renderer, use the existing ones as reference and use the below
 
 `theme: "Dark" | "Light"`
 
-The name of the current Roblox Studio theme.
+Deprecated. This prop is always `"Dark"` and is only kept for backwards compatibility; hosts like Flipbook supply the real theme themselves via extra props.
 
 #### container
 
@@ -51,11 +51,11 @@ The location where GuiObjects will be rendered to.
 
 Reference to the Story that is being rendered.
 
-#### storybook
+#### story.storybook
 
-`storybook: Storybook`
+`story.storybook: LoadedStorybook`
 
-Reference to the Storybook that the Story is a part of.
+Reference to the Storybook that the Story is a part of, available on the `story` prop.
 
 #### controls
 
@@ -66,45 +66,50 @@ All the values provided by the story controls. The contents of this vary based o
 ### Renderer
 
 ```lua
-export type Renderer = {
-	mount: (container: Instance, element: unknown, context: Context) -> GuiObject | Folder,
-	update: ((controls: StoryControls<T>) -> ())?,
-
-	transformArgs: ((args: Args, context: Context) -> Args)?,
-	shouldUpdate: ((context: Context, prevContext: Context?) -> boolean)?,
-	unmount: ((context: Context) -> ())?,
+export type StoryRenderer<T> = {
+	mount: (container: Instance, story: LoadedStory<T>, initialProps: StoryProps) -> (),
+	unmount: (() -> ())?,
+	update: ((props: StoryProps, prevProps: StoryProps?) -> ())?,
+	transformProps: ((props: StoryProps, prevProps: StoryProps?) -> StoryProps)?,
+	shouldUpdate: ((props: StoryProps, prevProps: StoryProps?) -> boolean)?,
 }
 ```
 
 #### mount
 
-`mount(container: Instance, element: unknown, context: RenderContext)`
+`mount(container: Instance, story: LoadedStory<T>, initialProps: StoryProps)`
 
-This function handles the initial mounting of a UI element to the container.
+This function handles the initial mounting of a UI element to the container. The story being rendered is available as `story.story`.
 
-The first two arguments `container` and `element` are provided for convenience and are identical to `context.container` and `context.story.story`, respectively.
+If the renderer does not define `update`, `mount` is also called for every update (a full remount), guarded by `shouldUpdate` when defined.
 
 #### update
 
-`update(context: RenderContext, prevContext: RenderContext)`
+`update(props: StoryProps, prevProps: StoryProps?)`
 
-Called any time something changes to RenderContext and determines if the story should re-render, and how.
+Called any time the story's props change, typically from the user interacting with story controls. By comparing `props` and `prevProps` a renderer can choose how it wants to re-render the story.
 
-This is a general purpose function for handling any context change. For example, by comparing `context` and `prevContext` a renderer can choose how it wants to re-render a story when controls change. In the case of Roact new GuiObjects are created, whereas Fusion relies on stable identities and instead relies on `transformContext` to
+This hook is optional. When it is defined, the renderer is responsible for reflecting the new props in the rendered UI — for example, Fusion keeps its Instances' identities stable by pushing new control values through `Fusion.Value` objects. When it is not defined, the story is unmounted and remounted from scratch with the new props.
 
 #### unmount
 
 `unmount()`
 
-Called when a story is closed. This function handles cleanup for the `mount` function so there are no lingering UI elements between stories.
+Called when a story is closed. This function handles cleanup for the `mount` function so there are no lingering UI elements between stories. After it runs, the container's remaining children are cleared automatically.
 
-#### transformContext
+#### transformProps
 
-`transformContext(context: RenderContext, prevContext: RenderContext?): RenderContext`
+`transformProps(props: StoryProps, prevProps: StoryProps?): StoryProps`
 
-This function is always called before `mount` and `update` in order to transform the RenderContext object provided to them.
+This optional hook is called before `mount` and `update` in order to transform the props provided to them. The `prevProps` are the transformed props from the previous render, so a renderer can carry state across renders.
 
-For the Fusion renderer, `context.controls` has each of its values mapped to `Fusion.Value`, and if `prevContext` is supplied then each Value has `:set()` called on it. This ensures the rendered GuiObjects maintain stable identities, while still updating from changes to controls.
+For example, a renderer for a reactive UI library can map each value in `props.controls` to that library's state primitive (like `Fusion.Value` or `Vide.source`) so stories receive reactive state, reusing the previous render's objects on update to keep Instance identities stable.
+
+#### shouldUpdate
+
+`shouldUpdate(props: StoryProps, prevProps: StoryProps?): boolean`
+
+This optional hook gates the remount path: when the renderer has no `update` function, every update calls `mount` again, and returning `false` from `shouldUpdate` skips that remount. It is also consulted for the initial mount, where `prevProps` is `nil`.
 
 ## Usage
 

--- a/docs/docs/contributing/story-renderers.md
+++ b/docs/docs/contributing/story-renderers.md
@@ -37,7 +37,7 @@ When adding a new renderer, use the existing ones as reference and use the below
 
 `theme: "Dark" | "Light"`
 
-Deprecated. This prop is always `"Dark"` and is only kept for backwards compatibility; hosts like Flipbook supply the real theme themselves via extra props.
+Deprecated. This prop is always `"Dark"` and is only kept for backwards compatibility. Hosts like Flipbook supply the real theme themselves via extra props.
 
 #### container
 

--- a/src/createRendererForStory.luau
+++ b/src/createRendererForStory.luau
@@ -1,4 +1,5 @@
 local createFusionRenderer = require("@root/renderers/createFusionRenderer")
+local createIrisRenderer = require("@root/renderers/createIrisRenderer")
 local createManualRenderer = require("@root/renderers/createManualRenderer")
 local createReactRenderer = require("@root/renderers/createReactRenderer")
 local createRoactRenderer = require("@root/renderers/createRoactRenderer")
@@ -27,6 +28,8 @@ local function createRendererForStory<T>(story: LoadedStory<T>): StoryRenderer<a
 			return createReactRenderer(packages)
 		elseif packages.Fusion then
 			return createFusionRenderer(packages)
+		elseif packages.Iris then
+			return createIrisRenderer(packages)
 		end
 	end
 

--- a/src/createRendererForStory.spec.luau
+++ b/src/createRendererForStory.spec.luau
@@ -1,0 +1,201 @@
+local JestGlobals = require("@pkg/JestGlobals")
+
+local createStory = require("@root/test-utils/createStory")
+local types = require("@root/types")
+
+local afterEach = JestGlobals.afterEach
+local beforeEach = JestGlobals.beforeEach
+local expect = JestGlobals.expect
+local jest = JestGlobals.jest
+local test = JestGlobals.test
+
+type LoadedStory<T> = types.LoadedStory<T>
+
+local ROACT_RENDERER = { kind = "Roact" }
+local REACT_RENDERER = { kind = "React" }
+local FUSION_RENDERER = { kind = "Fusion" }
+local VIDE_RENDERER = { kind = "Vide" }
+local IRIS_RENDERER = { kind = "Iris" }
+local MANUAL_RENDERER = { kind = "Manual" }
+
+local mockCreateRoactRenderer = jest.fn()
+local mockCreateReactRenderer = jest.fn()
+local mockCreateFusionRenderer = jest.fn()
+local mockCreateVideRenderer = jest.fn()
+local mockCreateIrisRenderer = jest.fn()
+local mockCreateManualRenderer = jest.fn()
+
+local createRendererForStory
+
+beforeEach(function()
+	mockCreateRoactRenderer.mockReturnValue(ROACT_RENDERER)
+	mockCreateReactRenderer.mockReturnValue(REACT_RENDERER)
+	mockCreateFusionRenderer.mockReturnValue(FUSION_RENDERER)
+	mockCreateVideRenderer.mockReturnValue(VIDE_RENDERER)
+	mockCreateIrisRenderer.mockReturnValue(IRIS_RENDERER)
+	mockCreateManualRenderer.mockReturnValue(MANUAL_RENDERER)
+
+	local renderers = script.Parent.renderers
+
+	jest.mock(renderers.createRoactRenderer, function()
+		return mockCreateRoactRenderer
+	end)
+	jest.mock(renderers.createReactRenderer, function()
+		return mockCreateReactRenderer
+	end)
+	jest.mock(renderers.createFusionRenderer, function()
+		return mockCreateFusionRenderer
+	end)
+	jest.mock(renderers.createVideRenderer, function()
+		return mockCreateVideRenderer
+	end)
+	jest.mock(renderers.createIrisRenderer, function()
+		return mockCreateIrisRenderer
+	end)
+	jest.mock(renderers.createManualRenderer, function()
+		return mockCreateManualRenderer
+	end)
+
+	createRendererForStory = require("./createRendererForStory")
+end)
+
+afterEach(function()
+	jest.resetAllMocks()
+end)
+
+local function createStoryWithPackages(packages: types.StoryPackages?): LoadedStory<any>
+	return createStory({
+		story = function() end,
+		packages = packages,
+	})
+end
+
+test("selects the Roact renderer when Roact is provided", function()
+	local packages = { Roact = {} }
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(ROACT_RENDERER)
+	expect(mockCreateRoactRenderer).toHaveBeenCalledWith(packages)
+end)
+
+test("selects the React renderer when React and ReactRoblox are provided", function()
+	local packages = { React = {}, ReactRoblox = {} }
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(REACT_RENDERER)
+	expect(mockCreateReactRenderer).toHaveBeenCalledWith(packages)
+end)
+
+test("falls back to the Manual renderer when React is provided without ReactRoblox", function()
+	local renderer = createRendererForStory(createStoryWithPackages({ React = {} }))
+
+	expect(renderer).toBe(MANUAL_RENDERER)
+	expect(mockCreateReactRenderer).never.toHaveBeenCalled()
+end)
+
+test("selects the Fusion renderer when Fusion is provided", function()
+	local packages = { Fusion = {} }
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(FUSION_RENDERER)
+	expect(mockCreateFusionRenderer).toHaveBeenCalledWith(packages)
+end)
+
+test("selects the Vide renderer when Vide is provided", function()
+	local packages = { Vide = {} }
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(VIDE_RENDERER)
+	expect(mockCreateVideRenderer).toHaveBeenCalledWith(packages)
+end)
+
+test("selects the Iris renderer when Iris is provided", function()
+	local packages = { Iris = {} }
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(IRIS_RENDERER)
+	expect(mockCreateIrisRenderer).toHaveBeenCalledWith(packages)
+end)
+
+test("selects the Manual renderer when no packages are provided", function()
+	local renderer = createRendererForStory(createStoryWithPackages(nil))
+
+	expect(renderer).toBe(MANUAL_RENDERER)
+end)
+
+test("selects the Manual renderer when no packages match a UI library", function()
+	local renderer = createRendererForStory(createStoryWithPackages({ SomethingElse = {} }))
+
+	expect(renderer).toBe(MANUAL_RENDERER)
+end)
+
+test("prefers Roact over every other renderer", function()
+	local packages = {
+		Roact = {},
+		React = {},
+		ReactRoblox = {},
+		Fusion = {},
+		Vide = {},
+		Iris = {},
+	}
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(ROACT_RENDERER)
+end)
+
+test("prefers React over Fusion, Vide, and Iris", function()
+	local packages = {
+		React = {},
+		ReactRoblox = {},
+		Fusion = {},
+		Vide = {},
+		Iris = {},
+	}
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(REACT_RENDERER)
+end)
+
+test("prefers Fusion over Vide and Iris", function()
+	local packages = {
+		Fusion = {},
+		Vide = {},
+		Iris = {},
+	}
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(FUSION_RENDERER)
+end)
+
+test("prefers Vide over Iris", function()
+	local packages = {
+		Vide = {},
+		Iris = {},
+	}
+	local renderer = createRendererForStory(createStoryWithPackages(packages))
+
+	expect(renderer).toBe(VIDE_RENDERER)
+end)
+
+test("uses the storybook's packages when the story does not define its own", function()
+	local packages = { Vide = {} }
+	local story = createStoryWithPackages(nil)
+	story.storybook.packages = packages
+
+	local renderer = createRendererForStory(story)
+
+	expect(renderer).toBe(VIDE_RENDERER)
+	expect(mockCreateVideRenderer).toHaveBeenCalledWith(packages)
+end)
+
+test("the story's packages take precedence over the storybook's packages", function()
+	local storyPackages = { Vide = {} }
+	local story = createStoryWithPackages(storyPackages)
+	story.storybook.packages = { Roact = {} }
+
+	local renderer = createRendererForStory(story)
+
+	expect(renderer).toBe(VIDE_RENDERER)
+	expect(mockCreateVideRenderer).toHaveBeenCalledWith(storyPackages)
+	expect(mockCreateRoactRenderer).never.toHaveBeenCalled()
+end)

--- a/src/e2e/e2e.spec.luau
+++ b/src/e2e/e2e.spec.luau
@@ -20,10 +20,13 @@ local storybookModules = findStorybookModules(script.Parent.storybooks)
 
 local EXCLUDED_FROM_CONFORMANCE = {
 	script.Parent.storybooks["Hoarcekat.storybook"],
+	-- Iris is immediate-mode and cannot produce the top-level TextButton the
+	-- conformance tests expect, so its stories are exempt.
+	script.Parent.storybooks["Iris.storybook"],
 }
 
 test("pin number of storybooks", function()
-	expect(#storybookModules).toBe(4)
+	expect(#storybookModules).toBe(5)
 end)
 
 describeEach(storybookModules)("e2e %s", function(storybookModule)
@@ -42,7 +45,8 @@ describeEach(storybookModules)("e2e %s", function(storybookModule)
 			packages.ReactRoblox.act(function()
 				task.wait()
 			end)
-		elseif packages and packages.Fusion then
+		elseif packages and (packages.Fusion or packages.Iris) then
+			-- Fusion and Iris both render on their next cycle, so wait a frame.
 			task.wait()
 		end
 	end

--- a/src/e2e/e2e.spec.luau
+++ b/src/e2e/e2e.spec.luau
@@ -26,7 +26,7 @@ local EXCLUDED_FROM_CONFORMANCE = {
 }
 
 test("pin number of storybooks", function()
-	expect(#storybookModules).toBe(6)
+	expect(#storybookModules).toBe(7)
 end)
 
 describeEach(storybookModules)("e2e %s", function(storybookModule)

--- a/src/e2e/stories/iris/IrisText.story.luau
+++ b/src/e2e/stories/iris/IrisText.story.luau
@@ -1,0 +1,9 @@
+local Iris = require("@pkg/Iris")
+
+return {
+	story = function()
+		Iris.Window({ "Text Window" })
+		Iris.Text({ "Some text content" })
+		Iris.End()
+	end,
+}

--- a/src/e2e/stories/iris/IrisWindow.story.luau
+++ b/src/e2e/stories/iris/IrisWindow.story.luau
@@ -1,0 +1,13 @@
+local Iris = require("@pkg/Iris")
+
+-- Iris is immediate-mode, so controls are intentionally omitted: the shared
+-- conformance tests expect a top-level TextButton which Iris cannot produce.
+-- Control/update behaviour is covered by createIrisRenderer.spec.luau instead.
+return {
+	story = function()
+		Iris.Window({ "My Window" })
+		Iris.Text({ "Hello, World" })
+		Iris.Button({ "Save" })
+		Iris.End()
+	end,
+}

--- a/src/e2e/stories/roact/RoactButtonWithControls.story.luau
+++ b/src/e2e/stories/roact/RoactButtonWithControls.story.luau
@@ -1,0 +1,24 @@
+local Roact = require("@pkg/Roact")
+
+local function RoactButton(props)
+	return Roact.createElement("TextButton", {
+		Text = if props.isDisabled then "Disabled" else "Enabled",
+	})
+end
+
+local controls = {
+	isDisabled = false,
+}
+
+type Props = {
+	controls: typeof(controls),
+}
+
+return {
+	controls = controls,
+	story = function(props: Props)
+		return Roact.createElement(RoactButton, {
+			isDisabled = props.controls.isDisabled,
+		})
+	end,
+}

--- a/src/e2e/stories/roact/RoactSimpleTextLabel.story.luau
+++ b/src/e2e/stories/roact/RoactSimpleTextLabel.story.luau
@@ -1,0 +1,11 @@
+local Roact = require("@pkg/Roact")
+
+local function RoactTextLabel()
+	return Roact.createElement("TextLabel", {
+		Text = "Hello, World!",
+	})
+end
+
+return {
+	story = RoactTextLabel,
+}

--- a/src/e2e/storybooks/Iris.storybook.luau
+++ b/src/e2e/storybooks/Iris.storybook.luau
@@ -1,0 +1,12 @@
+local Iris = require("@pkg/Iris")
+
+local Root = script:FindFirstAncestor("e2e")
+
+return {
+	storyRoots = {
+		Root.stories.iris,
+	},
+	packages = {
+		Iris = Iris,
+	},
+}

--- a/src/e2e/storybooks/Roact.storybook.luau
+++ b/src/e2e/storybooks/Roact.storybook.luau
@@ -1,0 +1,12 @@
+local Roact = require("@pkg/Roact")
+
+local Root = script:FindFirstAncestor("e2e")
+
+return {
+	storyRoots = {
+		Root.stories.roact,
+	},
+	packages = {
+		Roact = Roact,
+	},
+}

--- a/src/render.spec.luau
+++ b/src/render.spec.luau
@@ -255,3 +255,120 @@ test("always passes reserved props", function()
 		})
 	)
 end)
+
+test("transformProps is applied before mount", function()
+	local mockMount = jest.fn()
+	local transformArgs = {}
+
+	mockCreateRendererForStory.mockReturnValue({
+		mount = mockMount,
+		transformProps = function(props, prevProps)
+			table.insert(transformArgs, { props = props, prevProps = prevProps })
+
+			local transformed = table.clone(props)
+			transformed.wasTransformed = true
+			return transformed
+		end,
+	})
+
+	render(container, story)
+
+	expect(#transformArgs).toBe(1)
+	expect(transformArgs[1].prevProps).toBeNil()
+	expect(mockMount).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.anything(),
+		expect.objectContaining({
+			wasTransformed = true,
+		})
+	)
+end)
+
+test("transformProps receives the previous props on update", function()
+	local mockUpdate = jest.fn()
+	local transformArgs = {}
+
+	mockCreateRendererForStory.mockReturnValue({
+		mount = function() end,
+		update = mockUpdate,
+		transformProps = function(props, prevProps)
+			table.insert(transformArgs, { props = props, prevProps = prevProps })
+
+			local transformed = table.clone(props)
+			transformed.wasTransformed = true
+			return transformed
+		end,
+	})
+
+	local lifecycle = render(container, story)
+
+	lifecycle.update()
+
+	expect(#transformArgs).toBe(2)
+	-- The previous props passed on update are the *transformed* props from
+	-- the initial render, so renderers can carry state (like Fusion Values)
+	-- across renders
+	expect(transformArgs[2].prevProps).toMatchObject({
+		wasTransformed = true,
+	})
+	expect(mockUpdate).toHaveBeenCalledWith(
+		expect.objectContaining({
+			wasTransformed = true,
+		}),
+		expect.anything()
+	)
+end)
+
+test("story props override extra props", function()
+	local mockMount = jest.fn()
+
+	mockCreateRendererForStory.mockReturnValue({
+		mount = mockMount,
+	})
+
+	story.props = {
+		conflicting = "from story",
+		storyOnly = true,
+	}
+
+	render(container, story, {
+		conflicting = "from extra props",
+		extraOnly = true,
+	})
+
+	expect(mockMount).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.anything(),
+		expect.objectContaining({
+			conflicting = "from story",
+			storyOnly = true,
+			extraOnly = true,
+		})
+	)
+end)
+
+test("reserved props cannot be overridden by story props", function()
+	local mockMount = jest.fn()
+
+	mockCreateRendererForStory.mockReturnValue({
+		mount = mockMount,
+	})
+
+	story.props = {
+		container = "spoofed container",
+		story = "spoofed story",
+		controls = "spoofed controls",
+	}
+
+	render(container, story)
+
+	expect(mockMount).toHaveBeenCalledWith(
+		expect.anything(),
+		expect.anything(),
+		expect.objectContaining({
+			container = container,
+			story = story,
+			controls = expect.any("table"),
+		})
+	)
+end)

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -42,7 +42,11 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		props = transformProps(props)
 		prevProps = props
 
-		if typeof(story.story) == "Instance" then
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+
+		if mapStory then
+			handle = mapStory(story.story)(props)
+		elseif typeof(story.story) == "Instance" then
 			handle = story.story
 		elseif typeof(story.story) == "function" then
 			handle = story.story(props)

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -64,9 +64,7 @@ describe("Fusion 0.3.0", function()
 	end)
 
 	test("unmount a Fusion component", function()
-		local story = createStory({
-			story = TextStory,
-		})
+		local story = createFusionStory(TextStory)
 		local lifecycle = render(container, story)
 
 		expect(#container:GetChildren()).toBe(1)
@@ -120,6 +118,35 @@ describe("Fusion 0.3.0", function()
 		task.wait()
 
 		expect(element.Text).toBe("Enabled")
+	end)
+
+	test("mount and unmount a story that is an Instance", function()
+		local instance = scope:New("TextLabel")({
+			Text = "Static",
+		})
+		local story = createFusionStory(instance)
+
+		local lifecycle = render(container, story)
+
+		expect(#container:GetChildren()).toBe(1)
+		expect(instance.Parent).toBe(container)
+
+		lifecycle.unmount()
+
+		expect(#container:GetChildren()).toBe(0)
+		expect(instance.Parent).toBeNil()
+	end)
+
+	test("errors thrown by the story propagate out of render", function()
+		local story = createFusionStory(function()
+			error("fusion story blew up")
+		end)
+
+		expect(function()
+			render(container, story)
+		end).toThrow("fusion story blew up")
+
+		expect(#container:GetChildren()).toBe(0)
 	end)
 end)
 
@@ -165,9 +192,7 @@ describe("Fusion 0.2.0", function()
 	end)
 
 	test("unmount a Fusion component", function()
-		local story = createStory({
-			story = TextStory,
-		})
+		local story = createFusionStory(TextStory)
 		local lifecycle = render(container, story)
 
 		expect(#container:GetChildren()).toBe(1)
@@ -221,5 +246,34 @@ describe("Fusion 0.2.0", function()
 		task.wait()
 
 		expect(element.Text).toBe("Enabled")
+	end)
+
+	test("mount and unmount a story that is an Instance", function()
+		local instance = New("TextLabel")({
+			Text = "Static",
+		})
+		local story = createFusionStory(instance)
+
+		local lifecycle = render(container, story)
+
+		expect(#container:GetChildren()).toBe(1)
+		expect(instance.Parent).toBe(container)
+
+		lifecycle.unmount()
+
+		expect(#container:GetChildren()).toBe(0)
+		expect(instance.Parent).toBeNil()
+	end)
+
+	test("errors thrown by the story propagate out of render", function()
+		local story = createFusionStory(function()
+			error("fusion story blew up")
+		end)
+
+		expect(function()
+			render(container, story)
+		end).toThrow("fusion story blew up")
+
+		expect(#container:GetChildren()).toBe(0)
 	end)
 end)

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -137,6 +137,38 @@ describe("Fusion 0.3.0", function()
 		expect(instance.Parent).toBeNil()
 	end)
 
+	test("mapStory middleware wraps the story", function()
+		local story = createFusionStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = true,
+		} :: StoryControlsSchema
+
+		story.storybook.mapStory = function(originalStory)
+			return function(props)
+				local instance = originalStory(props)
+				instance.Name = "Mapped"
+				return instance
+			end
+		end
+
+		local lifecycle = render(container, story)
+
+		local mapped = container:FindFirstChild("Mapped")
+		assert(mapped, "no mapped element found")
+		assert(mapped:IsA("TextButton"), "mapped element is not the story's TextButton")
+		expect(mapped.Text).toBe("Disabled")
+
+		-- Controls must keep working through the middleware
+		lifecycle.update({
+			isDisabled = false,
+		} :: StoryControls)
+
+		task.wait()
+
+		expect(mapped.Text).toBe("Enabled")
+	end)
+
 	test("errors thrown by the story propagate out of render", function()
 		local story = createFusionStory(function()
 			error("fusion story blew up")
@@ -263,6 +295,22 @@ describe("Fusion 0.2.0", function()
 
 		expect(#container:GetChildren()).toBe(0)
 		expect(instance.Parent).toBeNil()
+	end)
+
+	test("mapStory middleware wraps the story", function()
+		local story = createFusionStory(TextStory)
+
+		story.storybook.mapStory = function(originalStory)
+			return function(props)
+				local instance = originalStory(props)
+				instance.Name = "Mapped"
+				return instance
+			end
+		end
+
+		render(container, story)
+
+		expect(container:FindFirstChild("Mapped")).toBeDefined()
 	end)
 
 	test("errors thrown by the story propagate out of render", function()

--- a/src/renderers/createIrisRenderer.luau
+++ b/src/renderers/createIrisRenderer.luau
@@ -56,7 +56,7 @@ local function createIrisRenderer(packages: Packages): StoryRenderer<IrisStory>
 		Iris.Disabled = false
 
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
-		local storyFn: any = if mapStory then mapStory(story.story) else story.story
+		local storyFn: (props: StoryProps) -> any = if mapStory then mapStory(story.story) else story.story
 
 		disconnect = Iris:Connect(function()
 			if typeof(storyFn) == "function" then

--- a/src/renderers/createIrisRenderer.luau
+++ b/src/renderers/createIrisRenderer.luau
@@ -1,0 +1,94 @@
+local types = require("@root/types")
+
+type StoryProps = types.StoryProps
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryRenderer<T> = types.StoryRenderer<T>
+
+type IrisStory = (props: StoryProps) -> ()
+
+type Packages = {
+	Iris: any,
+}
+
+--[[
+	Iris is an immediate-mode UI library, so unlike the retained-mode renderers
+	it re-runs its connected callback every frame and reads state inline. There
+	are a few consequences this renderer has to account for:
+
+	- `Iris.Init` is a one-time global singleton and `Iris.Shutdown` is
+	  irreversible, so we initialise lazily on the first mount and re-point Iris
+	  at the new container on subsequent mounts instead of re-initialising.
+	- `Iris` errors each frame unless its parent is a `GuiBase2d`, but our
+	  containers are plain Folders, so we render into a Frame placed under the
+	  container.
+	- Controls are passed through as raw values; the story reads them every
+	  frame, so `update` simply swaps the props the callback closes over.
+]]
+local function createIrisRenderer(packages: Packages): StoryRenderer<IrisStory>
+	local Iris = packages.Iris
+
+	local wrapper: Instance?
+	local disconnect: (() -> ())?
+	local currentProps: StoryProps
+
+	local function mount(container: Instance, story: LoadedStory<IrisStory>, props: StoryProps)
+		currentProps = props
+
+		-- Iris requires a GuiBase2d parent, but the container may be a plain
+		-- Folder, so we render into a Frame that fills the container.
+		local frame = Instance.new("Frame")
+		frame.Size = UDim2.fromScale(1, 1)
+		frame.BackgroundTransparency = 1
+		frame.Parent = container
+		wrapper = frame
+
+		if not Iris.Internal._started then
+			-- `allowMultipleInits` guards against errors if Iris was already
+			-- initialised elsewhere (e.g. by the host application).
+			Iris.Init(frame, nil, true)
+		else
+			-- Iris can only be initialised once, so re-point the existing
+			-- instance at the new container and regenerate its root.
+			Iris.Internal.parentInstance = frame
+			Iris.ForceRefresh()
+		end
+
+		Iris.Disabled = false
+
+		disconnect = Iris:Connect(function()
+			if typeof(story.story) == "function" then
+				(story :: any).story(currentProps)
+			end
+		end)
+	end
+
+	local function update(props: StoryProps)
+		-- Immediate-mode: the connected callback reads `currentProps` every
+		-- frame, so swapping it in is all that's needed to re-render.
+		currentProps = props
+	end
+
+	local function unmount()
+		if disconnect then
+			disconnect()
+			disconnect = nil
+		end
+
+		-- Freeze Iris so the global cycle doesn't regenerate a root into the
+		-- container after we've torn it down.
+		Iris.Disabled = true
+
+		if wrapper then
+			wrapper:Destroy()
+			wrapper = nil
+		end
+	end
+
+	return {
+		mount = mount,
+		update = update,
+		unmount = unmount,
+	}
+end
+
+return createIrisRenderer

--- a/src/renderers/createIrisRenderer.luau
+++ b/src/renderers/createIrisRenderer.luau
@@ -55,9 +55,12 @@ local function createIrisRenderer(packages: Packages): StoryRenderer<IrisStory>
 
 		Iris.Disabled = false
 
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+		local storyFn: any = if mapStory then mapStory(story.story) else story.story
+
 		disconnect = Iris:Connect(function()
-			if typeof(story.story) == "function" then
-				(story :: any).story(currentProps)
+			if typeof(storyFn) == "function" then
+				storyFn(currentProps)
 			end
 		end)
 	end

--- a/src/renderers/createIrisRenderer.luau
+++ b/src/renderers/createIrisRenderer.luau
@@ -75,7 +75,8 @@ local function createIrisRenderer(packages: Packages): StoryRenderer<IrisStory>
 		end
 
 		-- Freeze Iris so the global cycle doesn't regenerate a root into the
-		-- container after we've torn it down.
+		-- container after we've torn it down. This is a singleton flag, so it
+		-- also pauses any host-app Iris UI running in the same session.
 		Iris.Disabled = true
 
 		if wrapper then

--- a/src/renderers/createIrisRenderer.spec.luau
+++ b/src/renderers/createIrisRenderer.spec.luau
@@ -4,6 +4,7 @@ local JestGlobals = require("@pkg/JestGlobals")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local waitFor = require("@root/test-utils/waitFor")
 
 local beforeEach = JestGlobals.beforeEach
 local expect = JestGlobals.expect
@@ -27,6 +28,15 @@ local function createIrisStory(story)
 	})
 end
 
+local function findTextLabelWithText(root: Instance, text: string): TextLabel?
+	for _, descendant in root:GetDescendants() do
+		if descendant:IsA("TextLabel") and descendant.Text == text then
+			return descendant
+		end
+	end
+	return nil
+end
+
 test("render an Iris component", function()
 	local story = createIrisStory(function()
 		Iris.Window({ "My Window" })
@@ -34,7 +44,7 @@ test("render an Iris component", function()
 		Iris.End()
 	end)
 
-	render(container, story)
+	local lifecycle = render(container, story)
 
 	-- Iris renders on its next cycle, so wait a frame before asserting.
 	task.wait()
@@ -43,7 +53,14 @@ test("render an Iris component", function()
 
 	local wrapper = container:FindFirstChildWhichIsA("Frame")
 	assert(wrapper, "no wrapper Frame was created")
-	expect(#wrapper:GetDescendants() > 0).toBe(true)
+
+	-- The first Iris cycle can take a couple of frames to draw widgets, so
+	-- poll rather than waiting a fixed number of frames
+	waitFor(function()
+		expect(findTextLabelWithText(wrapper, "Hello, World")).toBeDefined()
+	end)
+
+	lifecycle.unmount()
 end)
 
 test("unmount an Iris component", function()
@@ -61,6 +78,48 @@ test("unmount an Iris component", function()
 	lifecycle.unmount()
 
 	expect(#container:GetChildren()).toBe(0)
+end)
+
+test("a story can mount after a previous story unmounted", function()
+	local firstStory = createIrisStory(function()
+		Iris.Window({ "First Window" })
+		Iris.Text({ "First" })
+		Iris.End()
+	end)
+
+	local firstLifecycle = render(container, firstStory)
+
+	task.wait()
+
+	firstLifecycle.unmount()
+
+	-- Iris is a global singleton that can only be initialized once, so a
+	-- second mount must re-point the existing instance at the new container
+	local secondContainer = Instance.new("Folder")
+	local secondStory = createIrisStory(function()
+		Iris.Window({ "Second Window" })
+		Iris.Text({ "Second" })
+		Iris.End()
+	end)
+
+	local secondLifecycle = render(secondContainer, secondStory)
+
+	task.wait()
+
+	local wrapper = secondContainer:FindFirstChildWhichIsA("Frame")
+	assert(wrapper, "no wrapper Frame was created on the second mount")
+
+	waitFor(function()
+		expect(findTextLabelWithText(wrapper, "Second")).toBeDefined()
+	end)
+
+	-- The first story was unmounted, so its widgets must not leak into the
+	-- second story's render
+	expect(findTextLabelWithText(wrapper, "First")).toBeNil()
+
+	secondLifecycle.unmount()
+
+	expect(#secondContainer:GetChildren()).toBe(0)
 end)
 
 test("update passes new controls to the story", function()
@@ -89,4 +148,6 @@ test("update passes new controls to the story", function()
 	task.wait()
 
 	expect(rendered.value).toBe("updated")
+
+	lifecycle.unmount()
 end)

--- a/src/renderers/createIrisRenderer.spec.luau
+++ b/src/renderers/createIrisRenderer.spec.luau
@@ -1,0 +1,92 @@
+local Iris = require("@pkg/Iris")
+local JestGlobals = require("@pkg/JestGlobals")
+
+local ControlTypes = require("@root/controls/ControlTypes")
+local createStory = require("@root/test-utils/createStory")
+local render = require("@root/render")
+
+local beforeEach = JestGlobals.beforeEach
+local expect = JestGlobals.expect
+local test = JestGlobals.test
+
+type StoryControls = ControlTypes.StoryControls
+type StoryControlsSchema = ControlTypes.StoryControlsSchema
+
+local container
+
+beforeEach(function()
+	container = Instance.new("Folder")
+end)
+
+local function createIrisStory(story)
+	return createStory({
+		story = story,
+		packages = {
+			Iris = Iris,
+		},
+	})
+end
+
+test("render an Iris component", function()
+	local story = createIrisStory(function()
+		Iris.Window({ "My Window" })
+		Iris.Text({ "Hello, World" })
+		Iris.End()
+	end)
+
+	render(container, story)
+
+	-- Iris renders on its next cycle, so wait a frame before asserting.
+	task.wait()
+
+	expect(#container:GetChildren()).toBe(1)
+
+	local wrapper = container:FindFirstChildWhichIsA("Frame")
+	assert(wrapper, "no wrapper Frame was created")
+	expect(#wrapper:GetDescendants() > 0).toBe(true)
+end)
+
+test("unmount an Iris component", function()
+	local story = createIrisStory(function()
+		Iris.Window({ "My Window" })
+		Iris.End()
+	end)
+
+	local lifecycle = render(container, story)
+
+	task.wait()
+
+	expect(#container:GetChildren()).toBe(1)
+
+	lifecycle.unmount()
+
+	expect(#container:GetChildren()).toBe(0)
+end)
+
+test("update passes new controls to the story", function()
+	local rendered = {}
+
+	local story = createIrisStory(function(props)
+		rendered.value = props.controls.value
+		Iris.Window({ "My Window" })
+		Iris.End()
+	end)
+
+	story.controls = {
+		value = "initial",
+	} :: StoryControlsSchema
+
+	local lifecycle = render(container, story)
+
+	task.wait()
+
+	expect(rendered.value).toBe("initial")
+
+	lifecycle.update({
+		value = "updated",
+	} :: StoryControls)
+
+	task.wait()
+
+	expect(rendered.value).toBe("updated")
+end)

--- a/src/renderers/createIrisRenderer.spec.luau
+++ b/src/renderers/createIrisRenderer.spec.luau
@@ -136,6 +136,8 @@ test("mapStory middleware wraps the story", function()
 			Iris.Window({ "Middleware Window" })
 			Iris.Text({ "FromMiddleware" })
 			Iris.End()
+
+			return nil
 		end
 	end
 

--- a/src/renderers/createIrisRenderer.spec.luau
+++ b/src/renderers/createIrisRenderer.spec.luau
@@ -122,6 +122,36 @@ test("a story can mount after a previous story unmounted", function()
 	expect(#secondContainer:GetChildren()).toBe(0)
 end)
 
+test("mapStory middleware wraps the story", function()
+	local story = createIrisStory(function()
+		Iris.Window({ "My Window" })
+		Iris.Text({ "FromStory" })
+		Iris.End()
+	end)
+
+	story.storybook.mapStory = function(originalStory)
+		return function(props)
+			originalStory(props)
+
+			Iris.Window({ "Middleware Window" })
+			Iris.Text({ "FromMiddleware" })
+			Iris.End()
+		end
+	end
+
+	local lifecycle = render(container, story)
+
+	local wrapper = container:FindFirstChildWhichIsA("Frame")
+	assert(wrapper, "no wrapper Frame was created")
+
+	waitFor(function()
+		expect(findTextLabelWithText(wrapper, "FromStory")).toBeDefined()
+		expect(findTextLabelWithText(wrapper, "FromMiddleware")).toBeDefined()
+	end)
+
+	lifecycle.unmount()
+end)
+
 test("update passes new controls to the story", function()
 	local rendered = {}
 

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -17,7 +17,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		currentStory = story
 
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
-		local storyValue: any = if mapStory then mapStory(story.story) else story.story
+		local storyValue: Instance | ((...any) -> any) = if mapStory then mapStory(story.story) else story.story
 
 		local result
 

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -16,15 +16,18 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		currentContainer = container
 		currentStory = story
 
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+		local storyValue: any = if mapStory then mapStory(story.story) else story.story
+
 		local result
 
-		if typeof(story.story) == "Instance" then
-			result = story.story
-		elseif typeof(story.story) == "function" then
-			if debug.info(story.story, "a") >= 2 then
-				result = (story :: any).story(container, props)
+		if typeof(storyValue) == "Instance" then
+			result = storyValue
+		elseif typeof(storyValue) == "function" then
+			if debug.info(storyValue, "a") >= 2 then
+				result = storyValue(container, props)
 			else
-				result = (story :: any).story(props)
+				result = storyValue(props)
 			end
 		end
 

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -249,3 +249,23 @@ test("errors thrown by the story propagate out of render", function()
 
 	expect(#container:GetChildren()).toBe(0)
 end)
+
+test("mapStory middleware wraps the story", function()
+	local story = createStory({
+		story = function()
+			return Instance.new("TextLabel")
+		end,
+	})
+
+	story.storybook.mapStory = function(originalStory)
+		return function(props)
+			local instance = originalStory(props)
+			instance.Name = "Mapped"
+			return instance
+		end
+	end
+
+	render(container, story)
+
+	expect(container:FindFirstChild("Mapped")).toBeDefined()
+end)

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -160,3 +160,92 @@ test("lifecycle", function()
 
 	expect(#container:GetChildren()).toBe(0)
 end)
+
+test("mounts and unmounts a story that is an Instance", function()
+	local instance = Instance.new("TextLabel")
+	local story = createStory({
+		story = instance,
+	})
+
+	local lifecycle = render(container, story)
+
+	expect(#container:GetChildren()).toBe(1)
+	expect(instance.Parent).toBe(container)
+
+	lifecycle.unmount()
+
+	expect(#container:GetChildren()).toBe(0)
+end)
+
+test("a story function with two parameters receives the container first", function()
+	local receivedTarget
+	local receivedProps
+
+	local story = createStory({
+		story = function(target, props)
+			receivedTarget = target
+			receivedProps = props
+
+			local label = Instance.new("TextLabel")
+			label.Parent = target
+		end,
+	})
+
+	render(container, story)
+
+	expect(receivedTarget).toBe(container)
+	expect(receivedProps).toMatchObject({
+		container = container,
+	})
+	expect(#container:GetChildren()).toBe(1)
+end)
+
+test("the previous render is cleaned up exactly once per update", function()
+	local cleanups = 0
+
+	local story = createStory({
+		story = function(props)
+			local label = Instance.new("TextLabel")
+			label.Parent = props.container
+
+			return function()
+				cleanups += 1
+			end
+		end,
+	})
+
+	story.controls = {
+		isDisabled = false,
+	} :: StoryControlsSchema
+
+	local lifecycle = render(container, story)
+
+	expect(cleanups).toBe(0)
+
+	lifecycle.update({
+		isDisabled = true,
+	} :: StoryControls)
+
+	-- The update remounts from scratch, cleaning up the previous render
+	expect(cleanups).toBe(1)
+	expect(#container:GetChildren()).toBe(1)
+
+	lifecycle.unmount()
+
+	expect(cleanups).toBe(2)
+	expect(#container:GetChildren()).toBe(0)
+end)
+
+test("errors thrown by the story propagate out of render", function()
+	local story = createStory({
+		story = function()
+			error("manual story blew up")
+		end,
+	})
+
+	expect(function()
+		render(container, story)
+	end).toThrow("manual story blew up")
+
+	expect(#container:GetChildren()).toBe(0)
+end)

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -25,11 +25,6 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 
 	local function reactRender(story: types.LoadedStory<unknown>, props: StoryProps)
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
-		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
-
-		if mapDefinition then
-			story = mapDefinition(story)
-		end
 
 		local element
 		if isReactElement(story.story) then
@@ -47,6 +42,15 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 	end
 
 	local function mount(container: Instance, story: LoadedStory<T>, props: StoryProps)
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		-- The definition is mapped once here rather than in reactRender so
+		-- that updates re-render the already-mapped story instead of
+		-- transforming it a second time
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
 		root = ReactRoblox.createRoot(container)
 		reactRender(story, props)
 	end

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -207,6 +207,41 @@ test("lifecycle", function()
 	expect(#container:GetChildren()).toBe(0)
 end)
 
+test("unmounting runs effect cleanups", function()
+	local cleanedUp = false
+
+	local function StoryWithEffect()
+		React.useEffect(function()
+			return function()
+				cleanedUp = true
+			end
+		end, {})
+
+		return React.createElement("TextLabel", {
+			Text = "Effectful",
+		})
+	end
+
+	local lifecycle = render(container, createReactStory(StoryWithEffect))
+
+	act(function()
+		task.wait()
+	end)
+
+	expect(cleanedUp).toBe(false)
+
+	lifecycle.unmount()
+
+	act(function()
+		task.wait()
+	end)
+
+	-- Stories rely on their effect cleanups running when the story is
+	-- closed, so unmounting must go through React rather than only
+	-- clearing the container
+	expect(cleanedUp).toBe(true)
+end)
+
 describe("middleware", function()
 	test("supply context provider to all stories", function()
 		local ThemeContext = React.createContext(nil)

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -239,4 +239,146 @@ describe("middleware", function()
 		assert(element, "no TextLabel found")
 		expect(element.Text).toBe("Dark")
 	end)
+
+	test("mapStory continues to wrap the story on updates", function()
+		local ThemeContext = React.createContext(nil)
+
+		local function StoryThatNeedsContext(props: {
+			controls: {
+				isDisabled: boolean?,
+			},
+		})
+			local theme = React.useContext(ThemeContext)
+			local state = if props.controls.isDisabled then "Disabled" else "Enabled"
+
+			return React.createElement("TextLabel", {
+				Text = `{theme} {state}`,
+			})
+		end
+
+		local story = createReactStory(StoryThatNeedsContext)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapStory = function(element)
+			return function(props)
+				return React.createElement(ThemeContext.Provider, {
+					value = "Dark",
+				}, React.createElement(element, props))
+			end
+		end
+
+		local lifecycle = render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		local element = container:FindFirstChildWhichIsA("TextLabel")
+		assert(element, "no TextLabel found")
+		expect(element.Text).toBe("Dark Enabled")
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		act(function()
+			task.wait()
+		end)
+
+		element = container:FindFirstChildWhichIsA("TextLabel")
+		assert(element, "no TextLabel found")
+		expect(element.Text).toBe("Dark Disabled")
+	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createReactStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		expect(applications).toBe(1)
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		act(function()
+			task.wait()
+		end)
+
+		-- Updating re-renders the already-mapped story; the definition must
+		-- not be transformed a second time
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createReactStory(ButtonStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return React.createElement("TextLabel", {
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
+end)
+
+test("updating a pre-created element story does not error", function()
+	local story = createReactStory(React.createElement("TextLabel", {
+		Text = "Hello, World",
+	}))
+
+	local lifecycle = render(container, story)
+
+	act(function()
+		task.wait()
+	end)
+
+	expect(#container:GetChildren()).toBe(1)
+
+	lifecycle.update()
+
+	act(function()
+		task.wait()
+	end)
+
+	expect(#container:GetChildren()).toBe(1)
+
+	local label = container:FindFirstChildWhichIsA("TextLabel")
+	assert(label, "no TextLabel found")
+	expect(label.Text).toBe("Hello, World")
 end)

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -167,6 +167,33 @@ test("lifecycle", function()
 	expect(#container:GetChildren()).toBe(0)
 end)
 
+test("unmounting runs willUnmount", function()
+	local unmounted = false
+
+	local StoryWithWillUnmount = Roact.Component:extend("StoryWithWillUnmount")
+
+	function StoryWithWillUnmount:render()
+		return Roact.createElement("TextLabel", {
+			Text = "Effectful",
+		})
+	end
+
+	function StoryWithWillUnmount:willUnmount()
+		unmounted = true
+	end
+
+	local lifecycle = render(container, createRoactStory(StoryWithWillUnmount))
+
+	expect(unmounted).toBe(false)
+
+	lifecycle.unmount()
+
+	-- Stories rely on their lifecycle methods running when the story is
+	-- closed, so unmounting must go through Roact rather than only
+	-- clearing the container
+	expect(unmounted).toBe(true)
+end)
+
 describe("middleware", function()
 	test("supply context provider to all stories", function()
 		local ThemeContext = Roact.createContext(nil)

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -197,4 +197,103 @@ describe("middleware", function()
 		assert(element, "no TextLabel found")
 		expect(element.Text).toBe("Dark")
 	end)
+
+	test("mapStory continues to wrap the story on updates", function()
+		local ThemeContext = Roact.createContext(nil)
+
+		local function StoryThatNeedsContext(props: {
+			controls: {
+				isDisabled: boolean?,
+			},
+		})
+			local state = if props.controls.isDisabled then "Disabled" else "Enabled"
+
+			return Roact.createElement(ThemeContext.Consumer, {
+				render = function(theme)
+					return Roact.createElement("TextLabel", {
+						Text = `{theme} {state}`,
+					})
+				end,
+			})
+		end
+
+		local story = createRoactStory(StoryThatNeedsContext)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapStory = function(element)
+			return function(props)
+				return Roact.createElement(ThemeContext.Provider, {
+					value = "Dark",
+				}, Roact.createElement(element, props))
+			end
+		end
+
+		local lifecycle = render(container, story)
+
+		local element = container:FindFirstChildWhichIsA("TextLabel")
+		assert(element, "no TextLabel found")
+		expect(element.Text).toBe("Dark Enabled")
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		element = container:FindFirstChildWhichIsA("TextLabel")
+		assert(element, "no TextLabel found")
+		expect(element.Text).toBe("Dark Disabled")
+	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createRoactStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		expect(applications).toBe(1)
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		-- Updating re-renders the already-mapped story; the definition must
+		-- not be transformed a second time
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createRoactStory(ButtonStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return Roact.createElement("TextLabel", {
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)

--- a/src/renderers/createVideRenderer.luau
+++ b/src/renderers/createVideRenderer.luau
@@ -36,8 +36,12 @@ local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 		props = transformProps(props)
 		prevProps = props
 
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+
 		stopVide = Vide.mount(function()
-			if typeof(story.story) == "Instance" then
+			if mapStory then
+				return mapStory(story.story)(props)
+			elseif typeof(story.story) == "Instance" then
 				return story.story
 			else
 				return story.story(props)

--- a/src/renderers/createVideRenderer.spec.luau
+++ b/src/renderers/createVideRenderer.spec.luau
@@ -145,6 +145,22 @@ describe("Vide", function()
 		expect(#container:GetChildren()).toBe(0)
 	end)
 
+	test("mapStory middleware wraps the story", function()
+		local story = createVideStory(TextStory)
+
+		story.storybook.mapStory = function(originalStory)
+			return function(props)
+				local instance = originalStory(props)
+				instance.Name = "Mapped"
+				return instance
+			end
+		end
+
+		render(container, story)
+
+		expect(container:FindFirstChild("Mapped")).toBeDefined()
+	end)
+
 	test("errors thrown by the story propagate out of render", function()
 		local story = createVideStory(function()
 			error("vide story blew up")

--- a/src/renderers/createVideRenderer.spec.luau
+++ b/src/renderers/createVideRenderer.spec.luau
@@ -103,4 +103,57 @@ describe("Vide", function()
 
 		expect(element.Text).toBe("Enabled")
 	end)
+
+	test("unmounting destroys the reactive scope", function()
+		local cleaned = false
+
+		local story = createVideStory(function()
+			Vide.cleanup(function()
+				cleaned = true
+			end)
+
+			return Vide.create("TextLabel")({
+				Text = "Hello, world!",
+			})
+		end)
+
+		local lifecycle = render(container, story)
+
+		expect(cleaned).toBe(false)
+
+		lifecycle.unmount()
+
+		-- Stories rely on their `Vide.cleanup` callbacks running when the
+		-- story is closed, so unmounting must destroy the reactive scope
+		-- rather than only clearing the container
+		expect(cleaned).toBe(true)
+	end)
+
+	test("mount and unmount a story that is an Instance", function()
+		local instance = Vide.create("TextLabel")({
+			Text = "Static",
+		})
+		local story = createVideStory(instance)
+
+		local lifecycle = render(container, story)
+
+		expect(#container:GetChildren()).toBe(1)
+		expect(instance.Parent).toBe(container)
+
+		lifecycle.unmount()
+
+		expect(#container:GetChildren()).toBe(0)
+	end)
+
+	test("errors thrown by the story propagate out of render", function()
+		local story = createVideStory(function()
+			error("vide story blew up")
+		end)
+
+		expect(function()
+			render(container, story)
+		end).toThrow("vide story blew up")
+
+		expect(#container:GetChildren()).toBe(0)
+	end)
 end)

--- a/wally.toml
+++ b/wally.toml
@@ -27,6 +27,7 @@ UILabs = "pepeeltoro41/ui-labs@2.4.2"
 # [dev-dependencies]
 Fusion = "elttob/fusion@0.2.0"
 Fusion3 = "elttob/fusion@0.3.0"
+Iris = "sirmallard/iris@2.5.1"
 Jest = "jsdotlua/jest@3.10.0"
 JestGlobals = "jsdotlua/jest-globals@3.10.0"
 ReactRoblox = "jsdotlua/react-roblox@17.0.2"


### PR DESCRIPTION
## Problem

Story rendering is Storyteller's core value, but the renderer specs leave it under-protected: several lifecycle branches have no coverage at all (`createRendererForStory` has no spec, the `transformProps` hook is exercised by nothing, Instance-story branches and error paths are untested), two Fusion "unmount" tests silently exercise the Manual renderer because their stories omit `packages`, and nothing pins that unmounting releases resources (React effect cleanups, Roact `willUnmount`, Vide reactive scopes). Two real behavior bugs were hiding in the gaps:

- The React renderer re-applies a storybook's `mapDefinition` middleware on **every** update instead of once at mount, so non-idempotent middleware stacks a new transformation per control change (the Roact renderer already did this correctly).
- A storybook's `mapStory` middleware is only honored by the React and Roact renderers — Fusion, Vide, Iris, and manual stories ignore it entirely (flipbook-labs/flipbook#552).

The contributing doc also describes a `Renderer` contract (`transformArgs`, `transformContext`, `Context`-based signatures) that does not exist in the code.

## Solution

Pin every renderer's full mount → update → unmount lifecycle through the public `render()` entry point, red-first, and fix the two behavior bugs the new tests caught:

- **New `createRendererForStory.spec`** covering every branch of the selection ladder (Roact → React+ReactRoblox → Fusion → Vide → Iris → Manual), the React-without-ReactRoblox fallthrough, and story-vs-storybook `packages` precedence.
- **`render.spec` additions** for the `transformProps` hook (called before mount, transformed props flow to `mount`/`update`, `prevProps` carries the previous *transformed* props) and props merge precedence (story props beat extra props; reserved `container`/`story`/`controls` can't be overridden).
- **Per-renderer additions**: Instance-story branches (Fusion 0.2/0.3, Vide, Manual), error propagation out of `render()`, resource release on unmount (React `useEffect` cleanups, Roact `willUnmount`, Vide `Vide.cleanup`), Manual's two-parameter arity detection and cleanup-once-per-update, Iris singleton re-point on remount (no widget leakage between stories), and middleware behavior on updates.
- **Fix: `mapDefinition` applied exactly once** at mount in the React renderer, matching Roact.
- **Fix: `mapStory` applied in every renderer** (closes the Storyteller side of flipbook-labs/flipbook#552). For Fusion/Vide/Iris/Manual the mapped function `mapStory(story.story)` replaces the story function and receives the story's props.
- **Roact e2e coverage** (storybook + conformance stories) so every framework goes through discovery → load → render.
- **Docs**: the `StoryRenderer` contract in `story-renderers.md` now matches `types.luau` (`transformProps`/`shouldUpdate`, real `mount`/`update`/`unmount` signatures), and Vide moves out of the "Future" list.

This PR folds in #125 (`add-iris-renderer`) via merge, resolving its conflicts with the Vide renderer on `main`; the Iris spec is reworked here (per-test unmounts so the singleton's connections don't leak across tests, content-level assertions, a remount-after-unmount test). Note: #125 predates the changewrite migration, so if this PR lands first an Iris feature changelog entry may be worth adding — the entries here only cover the two fixes.

### Note on the "new control key on update" edge

`hydrateControls` iterates the story's schema only, so a control key that wasn't in the schema at mount can never reach a renderer's `update` through the public contract — the Fusion/Vide "silently drop unknown keys" behavior is unreachable and deliberately not pinned.

## Verification

`lute run lint`, `lute run analyze --include-build`, and `lute run test` all pass locally (283 tests, 44 suites; cloud run via Open Cloud). Every new test was seen red once: test-first for the two behavior fixes (mapDefinition-once failed against the old React renderer; all five mapStory tests failed before the implementation), and break-the-code for the rest via the mutation matrix below.

### Mutation matrix (break-the-code evidence)

42 deliberate mutations across the rendering route, applied in 6 batched rounds with the full suite run per round (attribution cross-checked; one confound re-verified in isolation). 41 killed, 1 documented gap.

**`render.luau`**
| Mutation | Killed by |
| --- | --- |
| `unmount` drops `container:ClearAllChildren()` | render.spec "destroy all children of the container when rerendering…" |
| `update` ignores `renderer.update` (always remounts) | render.spec "transformProps receives the previous props on update"; e2e "rerenders on control changes" (Fusion/Vide identity) |
| `transformProps` never applied | render.spec "transformProps is applied before mount" |
| Props merge order flipped (reserved first) | render.spec "reserved props cannot be overridden by story props"; StoryContainer.spec; loadStoryModule.spec |
| `renderOnce` ignores `shouldUpdate` | render.spec "only rerender if shouldUpdate returns true" |

**`createRendererForStory.luau`**
| Mutation | Killed by |
| --- | --- |
| Fusion checked before Roact | "prefers Roact over every other renderer"; "prefers React over Fusion, Vide, and Iris" |
| React branch no longer requires ReactRoblox | "falls back to the Manual renderer when React is provided without ReactRoblox" |
| Storybook packages beat story packages | "the story's packages take precedence over the storybook's packages" |
| Storybook fallback dropped | "uses the storybook's packages when the story does not define its own" |
| Iris branch dropped | "selects the Iris renderer when Iris is provided"; e2e Iris lifecycle |

**`createReactRenderer.luau`**
| Mutation | Killed by |
| --- | --- |
| `unmount` no-op | "unmounting runs effect cleanups" |
| `update` no-op | "update the component on arg changes"; "lifecycle" |
| `isReactElement` always false | "render an element"; "renders primitives"; "updating a pre-created element story does not error"; e2e ReactElementAsStory |
| `mapDefinition` never applied | "mapDefinition can replace the story's component"; "mapDefinition is applied exactly once, at mount" |
| `mapStory` never wrapped | "supply context provider to all stories"; "mapStory continues to wrap the story on updates" |

**`createRoactRenderer.luau`**
| Mutation | Killed by |
| --- | --- |
| `unmount` no-op | "unmounting runs willUnmount" |
| `update` no-op | "update the component on arg changes" |
| `isRoactElement` always false | "render a pre-created Roact element" |
| `update` drops the `mapStory` re-wrap | "mapStory continues to wrap the story on updates" |
| `mapDefinition` re-applied on update | "mapDefinition is applied exactly once, at mount" |

**`createFusionRenderer.luau`**
| Mutation | Killed by |
| --- | --- |
| `unmount` no-op | **Not killed in isolation** — see note below |
| `update` skips `Value:set` | 0.2 + 0.3 "update the component on arg changes" |
| Controls passed raw (no `Value` wrap) | 0.2 "controls are transformed into Values"; 0.3 update/mapStory tests |
| Instance-story branch dropped | 0.2 + 0.3 "mount and unmount a story that is an Instance" |
| 0.3 scope never created | 0.3 "controls are transformed into Values" and update tests |
| `mapStory` ignored | 0.2 + 0.3 "mapStory middleware wraps the story" |

**`createVideRenderer.luau`**
| Mutation | Killed by |
| --- | --- |
| `stopVide` never called on unmount | "unmounting destroys the reactive scope" |
| `update` skips setting sources | "update the component on arg changes" |
| Controls passed raw (no `source` wrap) | "controls are transformed into Sources" |
| Instance-story branch dropped | "mount and unmount a story that is an Instance" |
| `mapStory` ignored | "mapStory middleware wraps the story" |

**`createManualRenderer.luau`**
| Mutation | Killed by |
| --- | --- |
| `unmount` skips the story's cleanup function | "the previous render is cleaned up exactly once per update" |
| `update` no-op | "update the GuiObject on arg changes" |
| Arity detection dropped | "a story function with two parameters receives the container first"; e2e Hoarcekat |
| Instance-story branch dropped | "mounts and unmounts a story that is an Instance" |
| Returned cleanup function never captured | "the previous render is cleaned up exactly once per update" |
| `mapStory` ignored | "mapStory middleware wraps the story" |

**`createIrisRenderer.luau`**
| Mutation | Killed by |
| --- | --- |
| `unmount` skips disconnect | "a story can mount after a previous story unmounted" (first story's widgets leak into the second) |
| `update` doesn't swap props | "update passes new controls to the story" (verified in isolation — masked by a same-round render.luau mutation in the batched run) |
| Remount never re-points `parentInstance` | "a story can mount after a previous story unmounted" |
| Mount never un-freezes (`Disabled` stays true) | same remount test; "update passes new controls to the story" |
| `mapStory` ignored | "mapStory middleware wraps the story" |

**Known gap (documented, accepted):** a no-op Fusion `unmount` survives in isolation because `render()` clears the container as a backstop (destroying the handle either way) and the renderer-internal 0.3 scope's `doCleanup` is unobservable through the public contract — unlike React/Roact/Vide, Fusion gives stories no cleanup-callback API to hook. This is defense-in-depth rather than a decorative test: the same backstop is itself pinned by render.spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
