### PR TITLE
Stop Charm's deep-freeze at the packages boundary

### DIFF
--- a/.changes/frozen-packages.md
+++ b/.changes/frozen-packages.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Fixed
+---
+
+Stop Charm's deep-freeze from reaching the module exports in a loaded storybook or story's `packages` (storyteller#100). UI libraries mutate their module-level state while rendering, so freezing them broke story rendering in Studio.

--- a/.changes/frozen-packages.md
+++ b/.changes/frozen-packages.md
@@ -3,4 +3,4 @@ bump: patch
 category: Fixed
 ---
 
-Stop Charm's deep-freeze from reaching the module exports in a loaded storybook or story's `packages` (storyteller#100). UI libraries mutate their module-level state while rendering, so freezing them broke story rendering in Studio.
+Keep a loaded storybook or story's `packages` mutable when Charm deep-freezes its state in Studio. The `packages` hold the module exports of UI libraries like React and Fusion, which reassign their own module-level state while rendering and cannot be frozen.

--- a/src/loadStoryModule.luau
+++ b/src/loadStoryModule.luau
@@ -122,7 +122,7 @@ local function loadStoryModule<T>(
 		packages = if isLegacyStory then {} else packages,
 	}
 
-	local merged: types.LoadedStory<T> = Sift.Dictionary.merge(loadedStory, story) :: any
+	local merged = Sift.Dictionary.merge(loadedStory, story) :: types.LoadedStory<T>
 
 	local mergedPackages = merged.packages
 	if mergedPackages and getmetatable(mergedPackages :: any) == nil then

--- a/src/loadStoryModule.luau
+++ b/src/loadStoryModule.luau
@@ -122,7 +122,19 @@ local function loadStoryModule<T>(
 		packages = if isLegacyStory then {} else packages,
 	}
 
-	return Sift.Dictionary.merge(loadedStory, story)
+	local merged: types.LoadedStory<T> = Sift.Dictionary.merge(loadedStory, story) :: any
+
+	local mergedPackages = merged.packages
+	if mergedPackages and getmetatable(mergedPackages :: any) == nil then
+		-- Hosts keep loaded stories in Charm state, which deep-freezes
+		-- everything it can reach in Studio, but skips tables that have a
+		-- metatable. The story's packages are foreign module exports that
+		-- must stay mutable, so freezing has to stop here
+		-- (flipbook-labs/storyteller#100)
+		merged.packages = setmetatable(table.clone(mergedPackages), {}) :: any
+	end
+
+	return merged
 end
 
 return loadStoryModule

--- a/src/loadStoryModule.spec.luau
+++ b/src/loadStoryModule.spec.luau
@@ -238,3 +238,47 @@ describe("roblox internal", function()
 		expect((story :: any).substories).toBeUndefined()
 	end)
 end)
+
+describe("frozen Charm state (Studio behavior)", function()
+	local Charm = require("@pkg/Charm")
+
+	local prevFrozen
+
+	beforeEach(function()
+		-- Charm only freezes state below optimization level 2, so tests run
+		-- with freezing off. Force it on to reproduce what Studio does.
+		prevFrozen = Charm.flags.frozen
+		Charm.flags.frozen = true
+	end)
+
+	afterEach(function()
+		Charm.flags.frozen = prevFrozen
+	end)
+
+	test("a loaded story's packages survive being stored in Charm state", function()
+		local storyModule = createMockStoryModule([[
+			return {
+				story = function() end,
+				packages = {
+					FakeUILibrary = {
+						internalState = {},
+					},
+				},
+			}
+		]])
+
+		local story = loadStoryModule(storyModule, mockPlainStorybook)
+
+		-- Hosts like Flipbook keep the loaded story in Charm state, which
+		-- deep-freezes everything it can reach. UI libraries mutate their
+		-- module-level state while rendering, so the story's packages must
+		-- stay mutable even after being stored.
+		local getStory, setStory = Charm.signal(nil :: any)
+		setStory(story)
+
+		local packages = getStory().packages
+		assert(packages, "loaded story has no packages")
+		expect(table.isfrozen(packages.FakeUILibrary)).toBe(false)
+		expect(table.isfrozen(packages.FakeUILibrary.internalState)).toBe(false)
+	end)
+end)

--- a/src/loadStoryModule.spec.luau
+++ b/src/loadStoryModule.spec.luau
@@ -1,3 +1,4 @@
+local Charm = require("@pkg/Charm")
 local JestGlobals = require("@pkg/JestGlobals")
 
 local loadStoryModule = require("./loadStoryModule")
@@ -240,8 +241,6 @@ describe("roblox internal", function()
 end)
 
 describe("frozen Charm state (Studio behavior)", function()
-	local Charm = require("@pkg/Charm")
-
 	local prevFrozen
 
 	beforeEach(function()

--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -48,6 +48,16 @@ local function loadStorybookModule(module: ModuleScript, providedLoader: ModuleL
 		result.packages = migrateLegacyPackages(result)
 	end
 
+	if result.packages and getmetatable(result.packages) == nil then
+		-- Loaded storybooks get stored in Charm state, which deep-freezes
+		-- everything it can reach in Studio, but skips tables that have a
+		-- metatable. UI libraries mutate their module-level state while
+		-- rendering (React reassigns ReactCurrentDispatcher.current on every
+		-- render), so freezing has to stop at this foreign-module boundary
+		-- (flipbook-labs/storyteller#100)
+		result.packages = setmetatable(table.clone(result.packages), {})
+	end
+
 	if not result.name then
 		local name = module.Name:gsub(constants.STORYBOOK_NAME_PATTERN, "")
 		if name == "" then

--- a/src/loadStorybookModule.luau
+++ b/src/loadStorybookModule.luau
@@ -54,7 +54,11 @@ local function loadStorybookModule(module: ModuleScript, providedLoader: ModuleL
 		-- metatable. UI libraries mutate their module-level state while
 		-- rendering (React reassigns ReactCurrentDispatcher.current on every
 		-- render), so freezing has to stop at this foreign-module boundary
-		-- (flipbook-labs/storyteller#100)
+		-- (flipbook-labs/storyteller#100).
+		--
+		-- The clone matters: when the storybook declares `packages` directly,
+		-- the table belongs to the author's module and may be shared between
+		-- storybooks or frozen, so we must not attach a metatable in place
 		result.packages = setmetatable(table.clone(result.packages), {})
 	end
 

--- a/src/stores/StorytellerStore.spec.luau
+++ b/src/stores/StorytellerStore.spec.luau
@@ -1,3 +1,4 @@
+local Charm = require("@pkg/Charm")
 local JestGlobals = require("@pkg/JestGlobals")
 
 local new = require("@root/test-utils/new")
@@ -474,8 +475,6 @@ describe("orphaned stories", function()
 end)
 
 describe("frozen Charm state (Studio behavior)", function()
-	local Charm = require("@pkg/Charm")
-
 	local prevFrozen
 
 	beforeEach(function()

--- a/src/stores/StorytellerStore.spec.luau
+++ b/src/stores/StorytellerStore.spec.luau
@@ -5,6 +5,7 @@ local waitFor = require("@root/test-utils/waitFor")
 
 local StorytellerStore = require("./StorytellerStore")
 
+local beforeEach = JestGlobals.beforeEach
 local describe = JestGlobals.describe
 local expect = JestGlobals.expect
 local test = JestGlobals.test
@@ -469,5 +470,56 @@ describe("orphaned stories", function()
 			expect(#store.getLoadedStorybooks()).toBe(0)
 			expect(store.getOrphanedStoryModules()).toEqual({ storyA, storyB })
 		end)
+	end)
+end)
+
+describe("frozen Charm state (Studio behavior)", function()
+	local Charm = require("@pkg/Charm")
+
+	local prevFrozen
+
+	beforeEach(function()
+		-- Charm only freezes state below optimization level 2, so tests run
+		-- with freezing off. Force it on to reproduce what Studio does.
+		prevFrozen = Charm.flags.frozen
+		Charm.flags.frozen = true
+	end)
+
+	afterEach(function()
+		Charm.flags.frozen = prevFrozen
+	end)
+
+	test("loading storybooks does not freeze their package module exports", function()
+		local storybookModule = new("ModuleScript", {
+			Source = [[
+				return {
+					storyRoots = {},
+					packages = {
+						FakeUILibrary = {
+							internalState = {},
+						},
+					},
+				}
+			]],
+		})
+
+		local root = new("Folder", nil, {
+			["A.storybook"] = storybookModule,
+		})
+
+		store = StorytellerStore.new(root)
+		store.start()
+
+		waitFor(function()
+			expect(#store.getLoadedStorybooks()).toBe(1)
+		end)
+
+		-- UI libraries mutate their module-level state while rendering (React
+		-- reassigns ReactCurrentDispatcher.current on every render), so the
+		-- exports a storybook hands us must never be frozen by the store
+		local packages = store.getLoadedStorybooks()[1].packages
+		assert(packages, "loaded storybook has no packages")
+		expect(table.isfrozen(packages.FakeUILibrary)).toBe(false)
+		expect(table.isfrozen(packages.FakeUILibrary.internalState)).toBe(false)
 	end)
 end)


### PR DESCRIPTION
## Problem

Closes #100.

In Studio, Charm deep-freezes every table stored in its state: `flags.frozen` defaults to `not IS_O2`, and only test/production builds run at O2. `deepFreeze` recursively `table.freeze`s everything it can reach, skipping only tables that already have a metatable.

A `LoadedStorybook` carries `packages` — the **live module exports** of React, Fusion, Vide, and friends. When `StorytellerStore` stores loaded storybooks in a Charm signal, the freeze walks into those exports. React's export table has no metatable and exposes `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`, whose members (`ReactCurrentDispatcher`, `ReactCurrentOwner`, `ReactCurrentBatchConfig`) are plain tables that React **reassigns on every render**. Freezing them breaks story rendering outright, which is what forced Flipbook's blanket `Charm.flags.frozen = false` workaround (flipbook-labs/flipbook#515). The same applies to a `LoadedStory`'s `packages` when a host keeps the loaded story in its own Charm state.

This is also why Storyteller's own suite never caught it: cloud test runs execute at O2, where `flags.frozen` is off, so the freeze never happens in CI.

## Solution

Stop the freeze exactly at the foreign-module boundary. Charm's `deepFreeze` skips tables with metatables, so `loadStorybookModule` and `loadStoryModule` now hand back `packages` as a shallow clone carrying an empty metatable. Everything else about a loaded storybook or story stays freezable — Charm's immutability model still applies to Storyteller's own state — but the UI libraries' exports remain mutable, as they must be.

Two regression tests pin the contract red-first, both forcing `Charm.flags.frozen = true` to reproduce the Studio behavior CI can't see:

- `StorytellerStore.spec`: loading a storybook through the store must not freeze its package exports (fails on `main`).
- `loadStoryModule.spec`: a loaded story's packages survive being stored in Charm state (fails on `main`).

## Follow-up for Flipbook

Once this lands and Flipbook picks it up, the `Charm.flags.frozen = false` patch from flipbook-labs/flipbook#515 should be removable — re-enabling Charm's freeze checks in Studio is the whole point of #100. Worth one manual Studio pass at that point to confirm no *other* frozen-state mutation is lurking (this PR eliminates the one reachable through Storyteller's loaders, and I found no other table-holding atom in the store: `unavailableStorybooks` holds only plain data, and the module arrays hold Instances, which `deepFreeze` ignores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
