### PR TITLE
Apply mapDefinition exactly once in the React renderer

### DIFF
--- a/.changes/react-mapdefinition.md
+++ b/.changes/react-mapdefinition.md
@@ -3,4 +3,4 @@ bump: patch
 category: Fixed
 ---
 
-Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story, matching the Roact renderer. Previously every control change re-applied it to the already-mapped story, stacking transformations for non-idempotent middleware.
+Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story, matching the Roact renderer. Control changes re-render the already-mapped story rather than re-applying the middleware, so a non-idempotent `mapDefinition` no longer stacks transformations on every update.

--- a/.changes/react-mapdefinition.md
+++ b/.changes/react-mapdefinition.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Fixed
+---
+
+Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story, matching the Roact renderer. Previously every control change re-applied it to the already-mapped story, stacking transformations for non-idempotent middleware.

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -25,11 +25,6 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 
 	local function reactRender(story: types.LoadedStory<unknown>, props: StoryProps)
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
-		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
-
-		if mapDefinition then
-			story = mapDefinition(story)
-		end
 
 		local element
 		if isReactElement(story.story) then
@@ -47,6 +42,15 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 	end
 
 	local function mount(container: Instance, story: LoadedStory<T>, props: StoryProps)
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		-- The definition is mapped once here rather than in reactRender so
+		-- that updates re-render the already-mapped story instead of
+		-- transforming it a second time
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
 		root = ReactRoblox.createRoot(container)
 		reactRender(story, props)
 	end

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -239,4 +239,67 @@ describe("middleware", function()
 		assert(element, "no TextLabel found")
 		expect(element.Text).toBe("Dark")
 	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createReactStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		expect(applications).toBe(1)
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		act(function()
+			task.wait()
+		end)
+
+		-- Updating re-renders the already-mapped story; the definition must
+		-- not be transformed a second time
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createReactStory(ButtonStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return React.createElement("TextLabel", {
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -270,7 +270,7 @@ describe("middleware", function()
 			task.wait()
 		end)
 
-		-- Updating re-renders the already-mapped story; the definition must
+		-- Updating re-renders the already-mapped story. The definition must
 		-- not be transformed a second time
 		expect(applications).toBe(1)
 

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -220,7 +220,7 @@ describe("middleware", function()
 			isDisabled = true,
 		} :: StoryControls)
 
-		-- Updating re-renders the already-mapped story; the definition must
+		-- Updating re-renders the already-mapped story. The definition must
 		-- not be transformed a second time
 		expect(applications).toBe(1)
 

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -197,4 +197,55 @@ describe("middleware", function()
 		assert(element, "no TextLabel found")
 		expect(element.Text).toBe("Dark")
 	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createRoactStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		expect(applications).toBe(1)
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		-- Updating re-renders the already-mapped story; the definition must
+		-- not be transformed a second time
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createRoactStory(ButtonStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return Roact.createElement("TextLabel", {
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)


### PR DESCRIPTION
## Problem

The React renderer applies a storybook's `mapDefinition` middleware inside its render routine, so every control change transforms the already-mapped story again. A non-idempotent `mapDefinition` (one that wraps or decorates the story) stacks another transformation per update. The Roact renderer applies it once at mount, so the two disagree.

## Solution

Move the `mapDefinition` application out of `reactRender` and into `mount`, matching Roact. Two new middleware tests pin the behavior in both renderers: the definition is applied exactly once across mount and update (seen red against the old React renderer), and a definition can replace the story's component.

Split out of #131 to keep it reviewable. Recommended merge order for the series: this PR, then the mapStory PR, then the spec-hardening PR, then the doc PR, then #125.

## Break-the-code evidence

| Mutation | Killed by |
| --- | --- |
| React: `mapDefinition` never applied | "mapDefinition can replace the story's component", "mapDefinition is applied exactly once, at mount" |
| Roact: `mapDefinition` re-applied on update | "mapDefinition is applied exactly once, at mount" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)