### PR TITLE
Apply mapStory middleware in the Fusion, Vide, and Manual renderers

### DIFF
--- a/.changes/map-story-remaining-renderers.md
+++ b/.changes/map-story-remaining-renderers.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+category: Fixed
+---
+
+Apply a storybook's `mapStory` middleware in the Fusion, Vide, and Manual renderers. Previously only React and Roact used it (flipbook-labs/flipbook#552), and the in-progress Iris renderer gains the same support in its own PR.

--- a/.changes/map-story-remaining-renderers.md
+++ b/.changes/map-story-remaining-renderers.md
@@ -3,4 +3,4 @@ bump: minor
 category: Fixed
 ---
 
-Apply a storybook's `mapStory` middleware in the Fusion, Vide, and Manual renderers. Previously only React and Roact used it (flipbook-labs/flipbook#552), and the in-progress Iris renderer gains the same support in its own PR.
+Apply a storybook's `mapStory` middleware in the Fusion, Vide, and Manual renderers, matching the existing behavior in React and Roact.

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -42,7 +42,11 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		props = transformProps(props)
 		prevProps = props
 
-		if typeof(story.story) == "Instance" then
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+
+		if mapStory then
+			handle = mapStory(story.story)(props)
+		elseif typeof(story.story) == "Instance" then
 			handle = story.story
 		elseif typeof(story.story) == "function" then
 			handle = story.story(props)

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -121,6 +121,38 @@ describe("Fusion 0.3.0", function()
 
 		expect(element.Text).toBe("Enabled")
 	end)
+
+	test("mapStory middleware wraps the story", function()
+		local story = createFusionStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = true,
+		} :: StoryControlsSchema
+
+		story.storybook.mapStory = function(originalStory)
+			return function(props)
+				local instance = originalStory(props)
+				instance.Name = "Mapped"
+				return instance
+			end
+		end
+
+		local lifecycle = render(container, story)
+
+		local mapped = container:FindFirstChild("Mapped")
+		assert(mapped, "no mapped element found")
+		assert(mapped:IsA("TextButton"), "mapped element is not the story's TextButton")
+		expect(mapped.Text).toBe("Disabled")
+
+		-- Controls must keep working through the middleware
+		lifecycle.update({
+			isDisabled = false,
+		} :: StoryControls)
+
+		task.wait()
+
+		expect(mapped.Text).toBe("Enabled")
+	end)
 end)
 
 describe("Fusion 0.2.0", function()
@@ -221,5 +253,21 @@ describe("Fusion 0.2.0", function()
 		task.wait()
 
 		expect(element.Text).toBe("Enabled")
+	end)
+
+	test("mapStory middleware wraps the story", function()
+		local story = createFusionStory(TextStory)
+
+		story.storybook.mapStory = function(originalStory)
+			return function(props)
+				local instance = originalStory(props)
+				instance.Name = "Mapped"
+				return instance
+			end
+		end
+
+		render(container, story)
+
+		expect(container:FindFirstChild("Mapped")).toBeDefined()
 	end)
 end)

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -17,9 +17,9 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		currentStory = story
 
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
-		local storyValue: Instance | ((...any) -> any) = if mapStory then mapStory(story.story) else story.story
+		local storyValue: Instance | ((...any) -> unknown) = if mapStory then mapStory(story.story) else story.story
 
-		local result
+		local result: unknown
 
 		if typeof(storyValue) == "Instance" then
 			result = storyValue
@@ -32,7 +32,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		end
 
 		if typeof(result) == "function" then
-			cleanup = result
+			cleanup = result :: CleanupFn
 		elseif typeof(result) == "Instance" then
 			if not result.Parent then
 				result.Parent = container

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -16,15 +16,18 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		currentContainer = container
 		currentStory = story
 
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+		local storyValue: Instance | ((...any) -> any) = if mapStory then mapStory(story.story) else story.story
+
 		local result
 
-		if typeof(story.story) == "Instance" then
-			result = story.story
-		elseif typeof(story.story) == "function" then
-			if debug.info(story.story, "a") >= 2 then
-				result = (story :: any).story(container, props)
+		if typeof(storyValue) == "Instance" then
+			result = storyValue
+		elseif typeof(storyValue) == "function" then
+			if debug.info(storyValue, "a") >= 2 then
+				result = storyValue(container, props)
 			else
-				result = (story :: any).story(props)
+				result = storyValue(props)
 			end
 		end
 

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -160,3 +160,23 @@ test("lifecycle", function()
 
 	expect(#container:GetChildren()).toBe(0)
 end)
+
+test("mapStory middleware wraps the story", function()
+	local story = createStory({
+		story = function()
+			return Instance.new("TextLabel")
+		end,
+	})
+
+	story.storybook.mapStory = function(originalStory)
+		return function(props)
+			local instance = originalStory(props)
+			instance.Name = "Mapped"
+			return instance
+		end
+	end
+
+	render(container, story)
+
+	expect(container:FindFirstChild("Mapped")).toBeDefined()
+end)

--- a/src/renderers/createVideRenderer.luau
+++ b/src/renderers/createVideRenderer.luau
@@ -36,8 +36,12 @@ local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 		props = transformProps(props)
 		prevProps = props
 
+		local mapStory = if story.storybook then story.storybook.mapStory else nil
+
 		stopVide = Vide.mount(function()
-			if typeof(story.story) == "Instance" then
+			if mapStory then
+				return mapStory(story.story)(props)
+			elseif typeof(story.story) == "Instance" then
 				return story.story
 			else
 				return story.story(props)

--- a/src/renderers/createVideRenderer.spec.luau
+++ b/src/renderers/createVideRenderer.spec.luau
@@ -103,4 +103,20 @@ describe("Vide", function()
 
 		expect(element.Text).toBe("Enabled")
 	end)
+
+	test("mapStory middleware wraps the story", function()
+		local story = createVideStory(TextStory)
+
+		story.storybook.mapStory = function(originalStory)
+			return function(props)
+				local instance = originalStory(props)
+				instance.Name = "Mapped"
+				return instance
+			end
+		end
+
+		render(container, story)
+
+		expect(container:FindFirstChild("Mapped")).toBeDefined()
+	end)
 end)


### PR DESCRIPTION
## Problem

A storybook's `mapStory` middleware only works for React and Roact stories. The Fusion, Vide, and Manual renderers never consult it, so middleware like a theme provider silently does nothing for those frameworks (flipbook-labs/flipbook#552).

## Solution

Apply `mapStory` in all three renderers. The mapped function `mapStory(story.story)` replaces the story function and receives the story's props, mirroring how the React renderer treats it. Each renderer gains a test that wraps the story through the middleware and asserts the wrapped result renders (all three seen red before the implementation). The Fusion test also exercises controls through the middleware on update.

The in-progress Iris renderer (#125) gains the same support in its own PR. Split out of #131 to keep it reviewable.

## Break-the-code evidence

| Mutation | Killed by |
| --- | --- |
| Fusion: `mapStory` ignored | 0.2 + 0.3 "mapStory middleware wraps the story" |
| Vide: `mapStory` ignored | "mapStory middleware wraps the story" |
| Manual: `mapStory` ignored | "mapStory middleware wraps the story" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)