### PR TITLE
Standardize mapDefinition across all renderers

### DIFF
--- a/.changes/mapdefinition-all-renderers.md
+++ b/.changes/mapdefinition-all-renderers.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+category: Features
+---
+
+Honor a storybook's `mapDefinition` middleware in the Fusion, Vide, and Manual renderers, matching the existing behavior in React and Roact. The definition is now transformed exactly once when a story mounts, regardless of which renderer is used.

--- a/.changes/mapdefinition-once-at-mount.md
+++ b/.changes/mapdefinition-once-at-mount.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Fixed
+---
+
+Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story, matching the other renderers. Control changes now re-render the already-mapped story rather than re-applying the middleware, so a non-idempotent `mapDefinition` no longer stacks transformations on every update.

--- a/.changes/mapdefinition-once-at-mount.md
+++ b/.changes/mapdefinition-once-at-mount.md
@@ -1,6 +1,6 @@
 ---
 bump: patch
-category: Fixed
+category: Fixes
 ---
 
 Apply a storybook's `mapDefinition` middleware exactly once when the React renderer mounts a story, matching the other renderers. Control changes now re-render the already-mapped story rather than re-applying the middleware, so a non-idempotent `mapDefinition` no longer stacks transformations on every update.

--- a/docs/docs/reference/story-format.md
+++ b/docs/docs/reference/story-format.md
@@ -11,6 +11,8 @@ The properties that can be used in the module are as follows:
 | `storyRoots` | `{ Instance }`       | Locations that the Storybook manages. Each instance will have its descendants searched for Story modules.                                                                                                                                                               |
 | `name`       | `string?`            | An optional name for the Storybook. Defaults to the module name with the extension removed. i.e. `Sample.storybook` becomes `Sample`.                                                                                                                                   |
 | `packages`   | `{ [string]: any }?` | An optional dictionary used for supplying the Storybook with the packages to use when rendering its Stories. This dictionary can also be supplied per-Story to change the renderer used, but it can be convenient to define your packages globally to avoid repetition. |
+| `mapStory`      | `((story: any) -> (props) -> any)?` | Optional [middleware](#middleware) that wraps every rendered Story, e.g. to supply a shared context provider.                                                                                                                                            |
+| `mapDefinition` | `((story: any) -> any)?`            | Optional [middleware](#middleware) that transforms every Story's definition before it renders.                                                                                                                                                          |
 
 The most basic Storybook module can be represented as:
 
@@ -19,6 +21,77 @@ return {
     storyRoots = {
         script.Parent.Components
     },
+}
+```
+
+## Middleware
+
+A Storybook can define middleware that runs against every Story it manages. This is handy for cross-cutting concerns like wrapping every Story in a theme provider or tagging Story names. Both hooks are optional and are honored by every renderer (React, Roact, Fusion, Vide, and the manual renderer).
+
+### mapStory
+
+```lua
+mapStory: (story) -> (props: StoryProps) -> element
+```
+
+`mapStory` wraps every Story with a component of your choosing. It receives the Story's component and returns a replacement component that renders in its place, which makes it the ideal spot to supply context providers or shared layout that each Story depends on.
+
+```lua title="WithTheme.storybook.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
+local ThemeContext = require(ReplicatedStorage.Packages.ThemeContext)
+
+return {
+    storyRoots = {
+        script.Parent.Components,
+    },
+    packages = {
+        React = React,
+        ReactRoblox = ReactRoblox,
+    },
+
+    mapStory = function(story)
+        return function(props)
+            return React.createElement(ThemeContext.Provider, {
+                value = "Dark",
+            }, React.createElement(story, props))
+        end
+    end,
+}
+```
+
+### mapDefinition
+
+```lua
+mapDefinition: (story) -> story
+```
+
+`mapDefinition` transforms a Story's definition before it is rendered. It receives the loaded Story and returns a (possibly modified) Story, so you can rewrite properties like `name`, adjust `controls`, or even swap out the `story` component entirely.
+
+`mapDefinition` is applied exactly once, when the Story mounts. Control changes re-render the already-mapped Story rather than running the middleware again, so transformations that would be incorrect if applied repeatedly (such as wrapping or decorating the Story) remain stable across updates.
+
+```lua title="WorkInProgress.storybook.luau"
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local React = require(ReplicatedStorage.Packages.React)
+local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
+
+return {
+    storyRoots = {
+        script.Parent.Components,
+    },
+    packages = {
+        React = React,
+        ReactRoblox = ReactRoblox,
+    },
+
+    mapDefinition = function(story)
+        local mapped = table.clone(story)
+        mapped.name = `[WIP] {story.name}`
+        return mapped
+    end,
 }
 ```
 

--- a/docs/docs/reference/story-format.md
+++ b/docs/docs/reference/story-format.md
@@ -26,7 +26,7 @@ return {
 
 ## Middleware
 
-A Storybook can define middleware that runs against every Story it manages. This is handy for cross-cutting concerns like wrapping every Story in a theme provider or tagging Story names. Both hooks are optional and are honored by every renderer (React, Roact, Fusion, Vide, and the manual renderer).
+A Storybook can define middleware that runs against every Story it manages. This is handy for cross-cutting concerns like wrapping every Story in a theme provider or tagging Story names. Both hooks are optional and are honored by every renderer.
 
 ### mapStory
 
@@ -41,7 +41,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local React = require(ReplicatedStorage.Packages.React)
 local ReactRoblox = require(ReplicatedStorage.Packages.ReactRoblox)
-local ThemeContext = require(ReplicatedStorage.Packages.ThemeContext)
+local ThemeContext = require(script.Parent.ThemeContext)
 
 return {
     storyRoots = {

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -42,6 +42,12 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		props = transformProps(props)
 		prevProps = props
 
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
 
 		if mapStory then

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -153,6 +153,60 @@ describe("Fusion 0.3.0", function()
 
 		expect(mapped.Text).toBe("Enabled")
 	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createFusionStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = true,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+
+		lifecycle.update({
+			isDisabled = false,
+		} :: StoryControls)
+
+		task.wait()
+
+		-- Updating mutates the existing controls rather than remounting, so
+		-- the definition must not be transformed a second time
+		expect(applications).toBe(1)
+		expect(button.Text).toBe("Enabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createFusionStory(TextStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return scope:New("TextLabel")({
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)
 
 describe("Fusion 0.2.0", function()
@@ -269,5 +323,59 @@ describe("Fusion 0.2.0", function()
 		render(container, story)
 
 		expect(container:FindFirstChild("Mapped")).toBeDefined()
+	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createFusionStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = true,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+
+		lifecycle.update({
+			isDisabled = false,
+		} :: StoryControls)
+
+		task.wait()
+
+		-- Updating mutates the existing controls rather than remounting, so
+		-- the definition must not be transformed a second time
+		expect(applications).toBe(1)
+		expect(button.Text).toBe("Enabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createFusionStory(TextStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return New("TextLabel")({
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
 	end)
 end)

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -182,8 +182,6 @@ describe("Fusion 0.3.0", function()
 
 		task.wait()
 
-		-- Updating mutates the existing controls rather than remounting, so
-		-- the definition must not be transformed a second time
 		expect(applications).toBe(1)
 		expect(button.Text).toBe("Enabled")
 	end)
@@ -353,8 +351,6 @@ describe("Fusion 0.2.0", function()
 
 		task.wait()
 
-		-- Updating mutates the existing controls rather than remounting, so
-		-- the definition must not be transformed a second time
 		expect(applications).toBe(1)
 		expect(button.Text).toBe("Enabled")
 	end)

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -42,9 +42,6 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
-		-- The definition is mapped once here rather than in renderStory so
-		-- that updates re-render the already-mapped story instead of
-		-- transforming it a second time
 		if mapDefinition then
 			story = mapDefinition(story)
 		end

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -12,10 +12,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 	local currentStory
 	local cleanup: (() -> ())?
 
-	local function mount(container: Instance, story: LoadedStory<ManualStory>, props: StoryProps)
-		currentContainer = container
-		currentStory = story
-
+	local function renderStory(story: LoadedStory<ManualStory>, props: StoryProps)
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
 		local storyValue: Instance | ((...any) -> unknown) = if mapStory then mapStory(story.story) else story.story
 
@@ -25,7 +22,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 			result = storyValue
 		elseif typeof(storyValue) == "function" then
 			if debug.info(storyValue, "a") >= 2 then
-				result = storyValue(container, props)
+				result = storyValue(currentContainer, props)
 			else
 				result = storyValue(props)
 			end
@@ -35,9 +32,25 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 			cleanup = result :: CleanupFn
 		elseif typeof(result) == "Instance" then
 			if not result.Parent then
-				result.Parent = container
+				result.Parent = currentContainer
 			end
 		end
+	end
+
+	local function mount(container: Instance, story: LoadedStory<ManualStory>, props: StoryProps)
+		currentContainer = container
+
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		-- The definition is mapped once here rather than in renderStory so
+		-- that updates re-render the already-mapped story instead of
+		-- transforming it a second time
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
+		currentStory = story
+		renderStory(story, props)
 	end
 
 	local function unmount()
@@ -51,7 +64,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 
 	local function update(props)
 		unmount()
-		mount(currentContainer, currentStory, props)
+		renderStory(currentStory, props)
 	end
 
 	return {

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -248,8 +248,6 @@ test("mapDefinition is applied exactly once, at mount", function()
 		isDisabled = false,
 	} :: StoryControls)
 
-	-- The manual renderer re-renders on update, but the definition is mapped
-	-- once at mount so it must not be transformed again
 	expect(applications).toBe(1)
 
 	button = container:FindFirstChildWhichIsA("TextButton")

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -180,3 +180,64 @@ test("mapStory middleware wraps the story", function()
 
 	expect(container:FindFirstChild("Mapped")).toBeDefined()
 end)
+
+test("mapDefinition is applied exactly once, at mount", function()
+	local applications = 0
+
+	local story = createStory({
+		story = ButtonStory,
+	})
+
+	story.controls = {
+		isDisabled = true,
+	} :: StoryControlsSchema
+
+	story.storybook.mapDefinition = function(storyDefinition)
+		applications += 1
+		return table.clone(storyDefinition)
+	end
+
+	local lifecycle = render(container, story)
+
+	expect(applications).toBe(1)
+
+	local button = container:FindFirstChildWhichIsA("TextButton")
+	assert(button, "no TextButton found")
+	expect(button.Text).toBe("Disabled")
+
+	lifecycle.update({
+		isDisabled = false,
+	} :: StoryControls)
+
+	-- The manual renderer re-renders on update, but the definition is mapped
+	-- once at mount so it must not be transformed again
+	expect(applications).toBe(1)
+
+	button = container:FindFirstChildWhichIsA("TextButton")
+	assert(button, "no TextButton found")
+	expect(button.Text).toBe("Enabled")
+end)
+
+test("mapDefinition can replace the story's component", function()
+	local story = createStory({
+		story = function()
+			return Instance.new("TextButton")
+		end,
+	})
+
+	story.storybook.mapDefinition = function(storyDefinition)
+		local mapped = table.clone(storyDefinition)
+		mapped.story = function()
+			local label = Instance.new("TextLabel")
+			label.Text = "Replaced"
+			return label
+		end
+		return mapped
+	end
+
+	render(container, story)
+
+	local label = container:FindFirstChildWhichIsA("TextLabel")
+	assert(label, "no TextLabel found")
+	expect(label.Text).toBe("Replaced")
+end)

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -125,6 +125,45 @@ test("update the GuiObject on arg changes", function()
 	expect(button.Text).toBe("Enabled")
 end)
 
+test("update re-renders a story that manages its own cleanup", function()
+	local cleanups = 0
+
+	local story = createStory({
+		story = function(props)
+			local label = Instance.new("TextLabel")
+			label.Text = if props.controls.isDisabled then "Disabled" else "Enabled"
+			label.Parent = props.container
+
+			return function()
+				cleanups += 1
+				label:Destroy()
+			end
+		end,
+	})
+
+	story.controls = {
+		isDisabled = true,
+	} :: StoryControlsSchema
+
+	local lifecycle = render(container, story)
+
+	local label = container:FindFirstChildWhichIsA("TextLabel")
+	assert(label, "no TextLabel found")
+	expect(label.Text).toBe("Disabled")
+
+	lifecycle.update({
+		isDisabled = false,
+	} :: StoryControls)
+
+	-- The previous render is cleaned up and a fresh one is mounted, just as a
+	-- full remount would do
+	expect(cleanups).toBe(1)
+
+	label = container:FindFirstChildWhichIsA("TextLabel")
+	assert(label, "no TextLabel found")
+	expect(label.Text).toBe("Enabled")
+end)
+
 test("lifecycle", function()
 	expect(#container:GetChildren()).toBe(0)
 

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -25,11 +25,6 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 
 	local function reactRender(story: types.LoadedStory<unknown>, props: StoryProps)
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
-		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
-
-		if mapDefinition then
-			story = mapDefinition(story)
-		end
 
 		local element
 		if isReactElement(story.story) then
@@ -47,6 +42,15 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 	end
 
 	local function mount(container: Instance, story: LoadedStory<T>, props: StoryProps)
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		-- The definition is mapped once here rather than in reactRender so
+		-- that updates re-render the already-mapped story instead of
+		-- transforming it a second time
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
 		root = ReactRoblox.createRoot(container)
 		reactRender(story, props)
 	end

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -44,9 +44,6 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 	local function mount(container: Instance, story: LoadedStory<T>, props: StoryProps)
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
-		-- The definition is mapped once here rather than in reactRender so
-		-- that updates re-render the already-mapped story instead of
-		-- transforming it a second time
 		if mapDefinition then
 			story = mapDefinition(story)
 		end

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -270,8 +270,6 @@ describe("middleware", function()
 			task.wait()
 		end)
 
-		-- Updating re-renders the already-mapped story. The definition must
-		-- not be transformed a second time
 		expect(applications).toBe(1)
 
 		local button = container:FindFirstChildWhichIsA("TextButton")

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -239,4 +239,67 @@ describe("middleware", function()
 		assert(element, "no TextLabel found")
 		expect(element.Text).toBe("Dark")
 	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createReactStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		expect(applications).toBe(1)
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		act(function()
+			task.wait()
+		end)
+
+		-- Updating re-renders the already-mapped story. The definition must
+		-- not be transformed a second time
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createReactStory(ButtonStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return React.createElement("TextLabel", {
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		act(function()
+			task.wait()
+		end)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -220,8 +220,6 @@ describe("middleware", function()
 			isDisabled = true,
 		} :: StoryControls)
 
-		-- Updating re-renders the already-mapped story. The definition must
-		-- not be transformed a second time
 		expect(applications).toBe(1)
 
 		local button = container:FindFirstChildWhichIsA("TextButton")

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -197,4 +197,55 @@ describe("middleware", function()
 		assert(element, "no TextLabel found")
 		expect(element.Text).toBe("Dark")
 	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createRoactStory(ButtonStory)
+
+		story.controls = {
+			isDisabled = false,
+		} :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		expect(applications).toBe(1)
+
+		lifecycle.update({
+			isDisabled = true,
+		} :: StoryControls)
+
+		-- Updating re-renders the already-mapped story. The definition must
+		-- not be transformed a second time
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no TextButton found")
+		expect(button.Text).toBe("Disabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createRoactStory(ButtonStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return Roact.createElement("TextLabel", {
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)

--- a/src/renderers/createVideRenderer.luau
+++ b/src/renderers/createVideRenderer.luau
@@ -36,6 +36,12 @@ local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 		props = transformProps(props)
 		prevProps = props
 
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
 
 		stopVide = Vide.mount(function()

--- a/src/renderers/createVideRenderer.spec.luau
+++ b/src/renderers/createVideRenderer.spec.luau
@@ -143,8 +143,6 @@ describe("Vide", function()
 
 		task.wait()
 
-		-- Updating mutates the existing sources rather than remounting, so
-		-- the definition must not be transformed a second time
 		expect(applications).toBe(1)
 		expect(button.Text).toBe("Enabled")
 	end)

--- a/src/renderers/createVideRenderer.spec.luau
+++ b/src/renderers/createVideRenderer.spec.luau
@@ -119,4 +119,53 @@ describe("Vide", function()
 
 		expect(container:FindFirstChild("Mapped")).toBeDefined()
 	end)
+
+	test("mapDefinition is applied exactly once, at mount", function()
+		local applications = 0
+
+		local story = createVideStory(ButtonStory)
+		story.controls = { isDisabled = true } :: StoryControlsSchema
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			applications += 1
+			return table.clone(storyDefinition)
+		end
+
+		local lifecycle = render(container, story)
+
+		expect(applications).toBe(1)
+
+		local button = container:FindFirstChildWhichIsA("TextButton")
+		assert(button, "no element found")
+		expect(button.Text).toBe("Disabled")
+
+		lifecycle.update({ isDisabled = false } :: StoryControls)
+
+		task.wait()
+
+		-- Updating mutates the existing sources rather than remounting, so
+		-- the definition must not be transformed a second time
+		expect(applications).toBe(1)
+		expect(button.Text).toBe("Enabled")
+	end)
+
+	test("mapDefinition can replace the story's component", function()
+		local story = createVideStory(TextStory)
+
+		story.storybook.mapDefinition = function(storyDefinition)
+			local mapped = table.clone(storyDefinition)
+			mapped.story = function()
+				return Vide.create("TextLabel")({
+					Text = "Replaced",
+				})
+			end
+			return mapped
+		end
+
+		render(container, story)
+
+		local label = container:FindFirstChildWhichIsA("TextLabel")
+		assert(label, "no TextLabel found")
+		expect(label.Text).toBe("Replaced")
+	end)
 end)


### PR DESCRIPTION
## Problem

A storybook's `mapDefinition` middleware was only ever consulted by the React and Roact renderers. Fusion, Vide, and the manual renderer silently ignored it, so a definition transform (e.g. renaming or decorating every story) did nothing for those frameworks.

On top of that, the React renderer applied `mapDefinition` inside its per-render routine, so every control change transformed the already-mapped story again. A non-idempotent `mapDefinition` stacked another transformation per update, while Roact (which applies it once at mount) disagreed. This is the bug #133 set out to fix.

Now that `mapStory` and `mapDefinition` have graduated from Roblox-internal experiments to hooks that are here to stay, this makes their behavior consistent and discoverable.

## Solution

Apply `mapDefinition` exactly once, at mount, in every renderer:

- **React** — move the mapping out of `reactRender` and into `mount`, so updates re-render the already-mapped story instead of transforming it a second time (the #133 fix).
- **Fusion**, **Vide**, **Manual** — honor `mapDefinition` for the first time. The manual renderer is restructured to extract a private `renderStory`, so its update path re-renders the stored, already-mapped story rather than remounting and re-mapping from scratch.
- **Roact** — already applied it once at mount; unchanged, but gains regression tests.

`mapStory` was already standardized across every renderer in #134, so it needed no code changes here — just documentation.

Every renderer spec gains two tests: the definition is applied exactly once across mount and update, and a definition can replace the story's component. Both hooks are now documented in the story format reference so authors can discover and use them.

## Break-the-code evidence

| Mutation | Killed by |
| --- | --- |
| React: `mapDefinition` re-applied on update | React "mapDefinition is applied exactly once, at mount" |
| Fusion / Vide / Manual: `mapDefinition` ignored | "mapDefinition can replace the story's component" (each renderer) |
| Manual: update remounts and re-maps the definition | Manual "mapDefinition is applied exactly once, at mount" |

## Notes

- Supersedes #133 (React-only fix); this PR folds in that change and extends it to the remaining renderers plus docs.
- Builds on #134, which standardized `mapStory` across Fusion, Vide, and the manual renderer.

Made with [Cursor](https://cursor.com)