### PR TITLE
Apply mapDefinition in the Iris renderer

### DIFF
--- a/.changes/iris-mapdefinition.md
+++ b/.changes/iris-mapdefinition.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+category: Features
+---
+
+Honor a storybook's `mapDefinition` middleware in the Iris renderer, matching the other renderers. The definition is transformed exactly once when a story mounts.

--- a/.changes/iris-renderer.md
+++ b/.changes/iris-renderer.md
@@ -3,4 +3,4 @@ bump: minor
 category: Features
 ---
 
-Add an Iris renderer so stories written with [Iris](https://github.com/SirMallard/Iris) can be previewed in a storybook. Iris is an immediate-mode global singleton, so the renderer initializes it lazily, re-points it at each newly mounted story, and freezes it on unmount.
+Add an [Iris](https://github.com/SirMallard/Iris) renderer so stories written with it can be previewed in a storybook.

--- a/src/e2e/e2e.spec.luau
+++ b/src/e2e/e2e.spec.luau
@@ -46,7 +46,6 @@ describeEach(storybookModules)("e2e %s", function(storybookModule)
 				task.wait()
 			end)
 		elseif packages and (packages.Fusion or packages.Vide or packages.Iris) then
-			-- Fusion, Vide, and Iris all render on their next cycle, so wait a frame.
 			task.wait()
 		end
 	end

--- a/src/renderers/createIrisRenderer.luau
+++ b/src/renderers/createIrisRenderer.luau
@@ -55,6 +55,12 @@ local function createIrisRenderer(packages: Packages): StoryRenderer<IrisStory>
 
 		Iris.Disabled = false
 
+		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
+
+		if mapDefinition then
+			story = mapDefinition(story)
+		end
+
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
 		local storyFn: (props: StoryProps) -> any = if mapStory then mapStory(story.story) else story.story
 

--- a/src/renderers/createIrisRenderer.spec.luau
+++ b/src/renderers/createIrisRenderer.spec.luau
@@ -183,3 +183,76 @@ test("update passes new controls to the story", function()
 
 	lifecycle.unmount()
 end)
+
+test("mapDefinition is applied exactly once, at mount", function()
+	local applications = 0
+	local rendered = {}
+
+	local story = createIrisStory(function(props)
+		rendered.value = props.controls.value
+		Iris.Window({ "My Window" })
+		Iris.Text({ props.controls.value })
+		Iris.End()
+	end)
+
+	story.controls = {
+		value = "initial",
+	} :: StoryControlsSchema
+
+	story.storybook.mapDefinition = function(storyDefinition)
+		applications += 1
+		return table.clone(storyDefinition)
+	end
+
+	local lifecycle = render(container, story)
+
+	task.wait()
+
+	expect(applications).toBe(1)
+	expect(rendered.value).toBe("initial")
+
+	lifecycle.update({
+		value = "updated",
+	} :: StoryControls)
+
+	task.wait()
+
+	-- Immediate-mode reads props every frame, so the update must re-render the
+	-- already-mapped story rather than re-applying the definition
+	expect(applications).toBe(1)
+	expect(rendered.value).toBe("updated")
+
+	lifecycle.unmount()
+end)
+
+test("mapDefinition can replace the story's component", function()
+	local story = createIrisStory(function()
+		Iris.Window({ "My Window" })
+		Iris.Text({ "Original" })
+		Iris.End()
+	end)
+
+	story.storybook.mapDefinition = function(storyDefinition)
+		local mapped = table.clone(storyDefinition)
+		mapped.story = function()
+			Iris.Window({ "Replaced Window" })
+			Iris.Text({ "Replaced" })
+			Iris.End()
+		end
+		return mapped
+	end
+
+	local lifecycle = render(container, story)
+
+	local wrapper = container:FindFirstChildWhichIsA("Frame")
+	assert(wrapper, "no wrapper Frame was created")
+
+	waitFor(function()
+		expect(findTextLabelWithText(wrapper, "Replaced")).toBeDefined()
+	end)
+
+	-- The original definition's widgets must not leak through once it's replaced
+	expect(findTextLabelWithText(wrapper, "Original")).toBeNil()
+
+	lifecycle.unmount()
+end)


### PR DESCRIPTION
## Problem

The Iris renderer landed in #125 just before #137 standardized `mapDefinition` across every other renderer. As a result, Iris is the only renderer that silently ignores a storybook's `mapDefinition` middleware — a definition transform (e.g. renaming or decorating every story) does nothing for Iris stories.

## Solution

Apply `mapDefinition` in the Iris renderer, once at mount, matching React, Roact, Fusion, Vide, and Manual:

- `createIrisRenderer.luau` — transform the story definition at mount, before `mapStory`. Because Iris is immediate-mode and `update` only swaps the props the connected callback closes over, the mapped `story.story` is captured a single time, so the definition is naturally applied exactly once across mount + updates (the same guarantee the retained-mode renderers make).
- `createIrisRenderer.spec.luau` — adds the two standard middleware tests every other renderer's spec gained in #137, adapted for immediate mode:
  - `mapDefinition is applied exactly once, at mount`
  - `mapDefinition can replace the story's component`

This also folds in two review comments from #125 that landed after it merged: removing a stale comment in the e2e conformance spec, and trimming the Iris changelog entry.

## Notes

- Verified locally: `lute run lint`, `lute run build --channel prod`, and `lute run analyze --include-build` all pass. The Jest suite runs against a Roblox place via OpenCloud and will run in CI.

Made with [Cursor](https://cursor.com)