### PR TITLE
Update AgentSkills to v0.5.0

### DIFF
--- a/.changes/update-agent-skills-v0.5.md
+++ b/.changes/update-agent-skills-v0.5.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+category: Dependencies
+---
+
+Update AgentSkills to `v0.5.0` for the durable-writing workflow.

--- a/loom.config.luau
+++ b/loom.config.luau
@@ -16,7 +16,7 @@ return {
 		},
 		dev_dependencies = {
 			AgentSkills = {
-				rev = "v0.4.0",
+				rev = "v0.5.0",
 				sourceKind = "github",
 				source = "https://github.com/flipbook-labs/agent-skills",
 			},


### PR DESCRIPTION
# Problem

Storyteller's agent guidance cannot route PR prose through the durable-writing workflow because its pinned AgentSkills release predates that skill.

# Solution

Update the development-only AgentSkills dependency to `v0.5.0`, which includes `org/durable-writing` and the expanded Flipbook workflow skills.

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)