### PR TITLE
Type StoryProps, StoryPackages, and the map middleware as unknown

### DIFF
--- a/.changes/unknown-typed-maps.md
+++ b/.changes/unknown-typed-maps.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+category: Changes
+---
+
+Type `StoryProps`, `StoryPackages`, `mapStory`, and `mapDefinition` values as `unknown` rather than `any`, so consumers narrow them before use.

--- a/src/e2e/e2e.spec.luau
+++ b/src/e2e/e2e.spec.luau
@@ -42,7 +42,8 @@ describeEach(storybookModules)("e2e %s", function(storybookModule)
 		local packages = if story then story.packages else storybook.packages
 
 		if packages and packages.React and packages.ReactRoblox then
-			packages.ReactRoblox.act(function()
+			local reactRoblox = packages.ReactRoblox :: { act: (() -> ()) -> () }
+			reactRoblox.act(function()
 				task.wait()
 			end)
 		elseif packages and (packages.Fusion or packages.Vide or packages.Iris) then

--- a/src/loadStoryModule.spec.luau
+++ b/src/loadStoryModule.spec.luau
@@ -32,7 +32,7 @@ beforeEach(function()
 				mount = jest.fn(),
 				unmount = jest.fn(),
 			},
-		},
+		} :: types.StoryPackages,
 	}
 
 	mockReactStorybook = {
@@ -46,7 +46,7 @@ beforeEach(function()
 			ReactRoblox = {
 				createRoot = jest.fn(),
 			},
-		},
+		} :: types.StoryPackages,
 	}
 end)
 
@@ -188,7 +188,7 @@ describe("legacy support", function()
 			source = Instance.new("ModuleScript"),
 			packages = {
 				Roact = {},
-			},
+			} :: types.StoryPackages,
 		}
 
 		local storyModule = createMockStoryModule([[

--- a/src/loadStoryModuleData.luau
+++ b/src/loadStoryModuleData.luau
@@ -75,7 +75,7 @@ local function normalizeStoryModule(requiredStory: unknown, storyModule: ModuleS
 			id = "default",
 			name = moduleName,
 			story = function(props: StoryProps)
-				return callback(props.container, props)
+				return callback(props.container :: Instance, props)
 			end,
 		}
 		return moduleName, { story }, true

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -3,12 +3,18 @@ local Sift = require("@pkg/Sift")
 local types = require("@root/types")
 
 type LoadedStory<T> = types.LoadedStory<T>
+type StoryControls = types.StoryControls
 type StoryProps = types.StoryProps
 type StoryRenderer<T> = types.StoryRenderer<T>
 
 type Packages = {
 	Fusion: any,
 }
+
+type FusionValue = {
+	set: (FusionValue, unknown) -> (),
+}
+type FusionValues = { [string]: FusionValue }
 
 local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 	local Fusion = packages.Fusion
@@ -25,8 +31,10 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 			scope = Fusion:scoped()
 		end
 
-		transformed.controls = Sift.Dictionary.map(props.controls, function(arg, key)
-			local prevControl = if prevProps and prevProps.controls then prevProps.controls[key] else nil
+		local prevControls: FusionValues? = if prevProps then prevProps.controls :: FusionValues? else nil
+
+		transformed.controls = Sift.Dictionary.map(props.controls :: StoryControls, function(arg, key)
+			local prevControl = if prevControls then prevControls[key] else nil
 
 			if prevControl ~= nil then
 				return prevControl
@@ -77,8 +85,10 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		-- we leave `handle` alone and mutate the controls with the newly
 		-- updated values
 		if prevProps then
-			for key, value in props.controls do
-				local prevControl = prevProps.controls[key]
+			local prevControls = prevProps.controls :: FusionValues
+
+			for key, value in props.controls :: StoryControls do
+				local prevControl = prevControls[key]
 
 				if prevControl ~= nil then
 					prevControl:set(value)

--- a/src/renderers/createFusionRenderer.luau
+++ b/src/renderers/createFusionRenderer.luau
@@ -45,13 +45,13 @@ local function createFusionRenderer(packages: Packages): StoryRenderer<Instance>
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
 		if mapDefinition then
-			story = mapDefinition(story)
+			story = mapDefinition(story) :: LoadedStory<Instance>
 		end
 
 		local mapStory = if story.storybook then story.storybook.mapStory else nil
 
 		if mapStory then
-			handle = mapStory(story.story)(props)
+			handle = mapStory(story.story)(props) :: Instance?
 		elseif typeof(story.story) == "Instance" then
 			handle = story.story
 		elseif typeof(story.story) == "function" then

--- a/src/renderers/createFusionRenderer.spec.luau
+++ b/src/renderers/createFusionRenderer.spec.luau
@@ -5,6 +5,7 @@ local JestGlobals = require("@pkg/JestGlobals")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local types = require("@root/types")
 
 local beforeEach = JestGlobals.beforeEach
 local expect = JestGlobals.expect
@@ -13,6 +14,8 @@ local describe = JestGlobals.describe
 
 type StoryControlsSchema = ControlTypes.StoryControlsSchema
 type StoryControls = ControlTypes.StoryControls
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 local container
 
@@ -130,8 +133,9 @@ describe("Fusion 0.3.0", function()
 		} :: StoryControlsSchema
 
 		story.storybook.mapStory = function(originalStory)
+			local storyFn = originalStory :: (StoryProps) -> Instance
 			return function(props)
-				local instance = originalStory(props)
+				local instance = storyFn(props)
 				instance.Name = "Mapped"
 				return instance
 			end
@@ -165,7 +169,7 @@ describe("Fusion 0.3.0", function()
 
 		story.storybook.mapDefinition = function(storyDefinition)
 			applications += 1
-			return table.clone(storyDefinition)
+			return table.clone(storyDefinition :: LoadedStory<unknown>)
 		end
 
 		local lifecycle = render(container, story)
@@ -190,7 +194,7 @@ describe("Fusion 0.3.0", function()
 		local story = createFusionStory(TextStory)
 
 		story.storybook.mapDefinition = function(storyDefinition)
-			local mapped = table.clone(storyDefinition)
+			local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 			mapped.story = function()
 				return scope:New("TextLabel")({
 					Text = "Replaced",
@@ -311,8 +315,9 @@ describe("Fusion 0.2.0", function()
 		local story = createFusionStory(TextStory)
 
 		story.storybook.mapStory = function(originalStory)
+			local storyFn = originalStory :: (StoryProps) -> Instance
 			return function(props)
-				local instance = originalStory(props)
+				local instance = storyFn(props)
 				instance.Name = "Mapped"
 				return instance
 			end
@@ -334,7 +339,7 @@ describe("Fusion 0.2.0", function()
 
 		story.storybook.mapDefinition = function(storyDefinition)
 			applications += 1
-			return table.clone(storyDefinition)
+			return table.clone(storyDefinition :: LoadedStory<unknown>)
 		end
 
 		local lifecycle = render(container, story)
@@ -359,7 +364,7 @@ describe("Fusion 0.2.0", function()
 		local story = createFusionStory(TextStory)
 
 		story.storybook.mapDefinition = function(storyDefinition)
-			local mapped = table.clone(storyDefinition)
+			local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 			mapped.story = function()
 				return New("TextLabel")({
 					Text = "Replaced",

--- a/src/renderers/createIrisRenderer.luau
+++ b/src/renderers/createIrisRenderer.luau
@@ -58,7 +58,7 @@ local function createIrisRenderer(packages: Packages): StoryRenderer<IrisStory>
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
 		if mapDefinition then
-			story = mapDefinition(story)
+			story = mapDefinition(story) :: LoadedStory<IrisStory>
 		end
 
 		local mapStory = if story.storybook then story.storybook.mapStory else nil

--- a/src/renderers/createIrisRenderer.spec.luau
+++ b/src/renderers/createIrisRenderer.spec.luau
@@ -4,6 +4,7 @@ local JestGlobals = require("@pkg/JestGlobals")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local types = require("@root/types")
 local waitFor = require("@root/test-utils/waitFor")
 
 local beforeEach = JestGlobals.beforeEach
@@ -12,6 +13,8 @@ local test = JestGlobals.test
 
 type StoryControls = ControlTypes.StoryControls
 type StoryControlsSchema = ControlTypes.StoryControlsSchema
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 local container
 
@@ -130,8 +133,9 @@ test("mapStory middleware wraps the story", function()
 	end)
 
 	story.storybook.mapStory = function(originalStory)
+		local storyFn = originalStory :: (StoryProps) -> ()
 		return function(props)
-			originalStory(props)
+			storyFn(props)
 
 			Iris.Window({ "Middleware Window" })
 			Iris.Text({ "FromMiddleware" })
@@ -201,7 +205,7 @@ test("mapDefinition is applied exactly once, at mount", function()
 
 	story.storybook.mapDefinition = function(storyDefinition)
 		applications += 1
-		return table.clone(storyDefinition)
+		return table.clone(storyDefinition :: LoadedStory<unknown>)
 	end
 
 	local lifecycle = render(container, story)
@@ -233,11 +237,12 @@ test("mapDefinition can replace the story's component", function()
 	end)
 
 	story.storybook.mapDefinition = function(storyDefinition)
-		local mapped = table.clone(storyDefinition)
+		local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 		mapped.story = function()
 			Iris.Window({ "Replaced Window" })
 			Iris.Text({ "Replaced" })
 			Iris.End()
+			return nil
 		end
 		return mapped
 	end

--- a/src/renderers/createManualRenderer.luau
+++ b/src/renderers/createManualRenderer.luau
@@ -43,7 +43,7 @@ local function createManualRenderer(): StoryRenderer<ManualStory>
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
 		if mapDefinition then
-			story = mapDefinition(story)
+			story = mapDefinition(story) :: LoadedStory<ManualStory>
 		end
 
 		currentStory = story

--- a/src/renderers/createManualRenderer.spec.luau
+++ b/src/renderers/createManualRenderer.spec.luau
@@ -3,6 +3,7 @@ local JestGlobals = require("@pkg/JestGlobals")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local types = require("@root/types")
 
 local beforeEach = JestGlobals.beforeEach
 local expect = JestGlobals.expect
@@ -10,6 +11,8 @@ local test = JestGlobals.test
 
 type StoryControlsSchema = ControlTypes.StoryControlsSchema
 type StoryControls = ControlTypes.StoryControls
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 local function ButtonStory(props: {
 	controls: {
@@ -208,8 +211,9 @@ test("mapStory middleware wraps the story", function()
 	})
 
 	story.storybook.mapStory = function(originalStory)
+		local storyFn = originalStory :: (StoryProps) -> TextLabel
 		return function(props)
-			local instance = originalStory(props)
+			local instance = storyFn(props)
 			instance.Name = "Mapped"
 			return instance
 		end
@@ -233,7 +237,7 @@ test("mapDefinition is applied exactly once, at mount", function()
 
 	story.storybook.mapDefinition = function(storyDefinition)
 		applications += 1
-		return table.clone(storyDefinition)
+		return table.clone(storyDefinition :: LoadedStory<unknown>)
 	end
 
 	local lifecycle = render(container, story)
@@ -263,7 +267,7 @@ test("mapDefinition can replace the story's component", function()
 	})
 
 	story.storybook.mapDefinition = function(storyDefinition)
-		local mapped = table.clone(storyDefinition)
+		local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 		mapped.story = function()
 			local label = Instance.new("TextLabel")
 			label.Text = "Replaced"

--- a/src/renderers/createReactRenderer.luau
+++ b/src/renderers/createReactRenderer.luau
@@ -45,7 +45,7 @@ local function createReactRenderer<T>(packages: Packages): StoryRenderer<T>
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
 		if mapDefinition then
-			story = mapDefinition(story)
+			story = mapDefinition(story) :: LoadedStory<T>
 		end
 
 		root = ReactRoblox.createRoot(container)

--- a/src/renderers/createReactRenderer.spec.luau
+++ b/src/renderers/createReactRenderer.spec.luau
@@ -5,6 +5,7 @@ local ReactRoblox = require("@pkg/ReactRoblox")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local types = require("@root/types")
 
 local beforeEach = JestGlobals.beforeEach
 local describe = JestGlobals.describe
@@ -15,6 +16,8 @@ local act = ReactRoblox.act
 
 type StoryControlsSchema = ControlTypes.StoryControlsSchema
 type StoryControls = ControlTypes.StoryControls
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 local function createReactStory(element)
 	return createStory({
@@ -222,10 +225,11 @@ describe("middleware", function()
 		local story = createReactStory(StoryThatNeedsContext)
 
 		story.storybook.mapStory = function(element)
+			local component = element :: React.FC<StoryProps>
 			return function(props)
 				return React.createElement(ThemeContext.Provider, {
 					value = "Dark",
-				}, React.createElement(element, props))
+				}, React.createElement(component, props))
 			end
 		end
 
@@ -251,7 +255,7 @@ describe("middleware", function()
 
 		story.storybook.mapDefinition = function(storyDefinition)
 			applications += 1
-			return table.clone(storyDefinition)
+			return table.clone(storyDefinition :: LoadedStory<unknown>)
 		end
 
 		local lifecycle = render(container, story)
@@ -281,7 +285,7 @@ describe("middleware", function()
 		local story = createReactStory(ButtonStory)
 
 		story.storybook.mapDefinition = function(storyDefinition)
-			local mapped = table.clone(storyDefinition)
+			local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 			mapped.story = function()
 				return React.createElement("TextLabel", {
 					Text = "Replaced",

--- a/src/renderers/createRoactRenderer.luau
+++ b/src/renderers/createRoactRenderer.luau
@@ -27,7 +27,7 @@ local function createRoactRenderer<T>(packages: Packages): StoryRenderer<T>
 		local element
 
 		if mapDefinition then
-			story = mapDefinition(story)
+			story = mapDefinition(story) :: LoadedStory<T>
 		end
 
 		if isRoactElement(story.story) then

--- a/src/renderers/createRoactRenderer.spec.luau
+++ b/src/renderers/createRoactRenderer.spec.luau
@@ -4,6 +4,7 @@ local Roact = require("@pkg/Roact")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local types = require("@root/types")
 
 local beforeEach = JestGlobals.beforeEach
 local describe = JestGlobals.describe
@@ -12,6 +13,7 @@ local test = JestGlobals.test
 
 type StoryControlsSchema = ControlTypes.StoryControlsSchema
 type StoryControls = ControlTypes.StoryControls
+type LoadedStory<T> = types.LoadedStory<T>
 
 local function createRoactStory(element)
 	return createStory({
@@ -209,7 +211,7 @@ describe("middleware", function()
 
 		story.storybook.mapDefinition = function(storyDefinition)
 			applications += 1
-			return table.clone(storyDefinition)
+			return table.clone(storyDefinition :: LoadedStory<unknown>)
 		end
 
 		local lifecycle = render(container, story)
@@ -231,7 +233,7 @@ describe("middleware", function()
 		local story = createRoactStory(ButtonStory)
 
 		story.storybook.mapDefinition = function(storyDefinition)
-			local mapped = table.clone(storyDefinition)
+			local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 			mapped.story = function()
 				return Roact.createElement("TextLabel", {
 					Text = "Replaced",

--- a/src/renderers/createVideRenderer.luau
+++ b/src/renderers/createVideRenderer.luau
@@ -1,12 +1,16 @@
 local types = require("@root/types")
 
 type LoadedStory<T> = types.LoadedStory<T>
+type StoryControls = types.StoryControls
 type StoryProps = types.StoryProps
 type StoryRenderer<T> = types.StoryRenderer<T>
 
 type Packages = {
 	Vide: any,
 }
+
+type VideSource = (unknown) -> unknown
+type VideSources = { [string]: VideSource }
 
 local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 	local Vide = packages.Vide
@@ -17,17 +21,20 @@ local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 	local function transformProps(props: StoryProps)
 		local transformed = table.clone(props)
 
-		transformed.controls = {}
+		local prevControls: VideSources? = if prevProps ~= nil then prevProps.controls :: VideSources? else nil
+		local sources: VideSources = {}
 
-		for key, control in props.controls do
-			local prevControl = if prevProps ~= nil and prevProps.controls ~= nil then prevProps.controls[key] else nil
+		for key, control in props.controls :: StoryControls do
+			local prevControl = if prevControls ~= nil then prevControls[key] else nil
 
 			if prevControl ~= nil then
-				transformed.controls[key] = prevControl
+				sources[key] = prevControl
 			else
-				transformed.controls[key] = Vide.source(control)
+				sources[key] = Vide.source(control)
 			end
 		end
+
+		transformed.controls = sources
 
 		return transformed
 	end
@@ -57,9 +64,11 @@ local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 
 	local function update(props: StoryProps)
 		if prevProps ~= nil then
+			local prevControls = prevProps.controls :: VideSources
+
 			Vide.batch(function()
-				for key, control in props.controls do
-					local prevControl = prevProps.controls[key]
+				for key, control in props.controls :: StoryControls do
+					local prevControl = prevControls[key]
 
 					if prevControl ~= nil then
 						prevControl(control)

--- a/src/renderers/createVideRenderer.luau
+++ b/src/renderers/createVideRenderer.luau
@@ -39,7 +39,7 @@ local function createVideRenderer(packages: Packages): StoryRenderer<Instance>
 		local mapDefinition = if story.storybook then story.storybook.mapDefinition else nil
 
 		if mapDefinition then
-			story = mapDefinition(story)
+			story = mapDefinition(story) :: LoadedStory<Instance>
 		end
 
 		local mapStory = if story.storybook then story.storybook.mapStory else nil

--- a/src/renderers/createVideRenderer.spec.luau
+++ b/src/renderers/createVideRenderer.spec.luau
@@ -4,6 +4,7 @@ local Vide = require("@pkg/Vide")
 local ControlTypes = require("@root/controls/ControlTypes")
 local createStory = require("@root/test-utils/createStory")
 local render = require("@root/render")
+local types = require("@root/types")
 
 local beforeEach = JestGlobals.beforeEach
 local describe = JestGlobals.describe
@@ -12,6 +13,8 @@ local test = JestGlobals.test
 
 type StoryControlsSchema = ControlTypes.StoryControlsSchema
 type StoryControls = ControlTypes.StoryControls
+type LoadedStory<T> = types.LoadedStory<T>
+type StoryProps = types.StoryProps
 
 local container
 beforeEach(function()
@@ -108,8 +111,9 @@ describe("Vide", function()
 		local story = createVideStory(TextStory)
 
 		story.storybook.mapStory = function(originalStory)
+			local storyFn = originalStory :: (StoryProps) -> Instance
 			return function(props)
-				local instance = originalStory(props)
+				local instance = storyFn(props)
 				instance.Name = "Mapped"
 				return instance
 			end
@@ -128,7 +132,7 @@ describe("Vide", function()
 
 		story.storybook.mapDefinition = function(storyDefinition)
 			applications += 1
-			return table.clone(storyDefinition)
+			return table.clone(storyDefinition :: LoadedStory<unknown>)
 		end
 
 		local lifecycle = render(container, story)
@@ -151,7 +155,7 @@ describe("Vide", function()
 		local story = createVideStory(TextStory)
 
 		story.storybook.mapDefinition = function(storyDefinition)
-			local mapped = table.clone(storyDefinition)
+			local mapped = table.clone(storyDefinition :: LoadedStory<unknown>)
 			mapped.story = function()
 				return Vide.create("TextLabel")({
 					Text = "Replaced",

--- a/src/stores/StorytellerStore.spec.luau
+++ b/src/stores/StorytellerStore.spec.luau
@@ -633,7 +633,7 @@ describe("requesting story modules", function()
 			Package = {
 				state = packageState,
 			},
-		}
+		} :: types.StoryPackages
 
 		store.requestStoryModules({ target })
 

--- a/src/types.luau
+++ b/src/types.luau
@@ -40,11 +40,11 @@ export type StoryRenderer<T> = {
 }
 
 export type StoryPackages = {
-	[string]: any,
+	[string]: unknown,
 }
 
-type MapStoryFn = (story: any) -> (props: StoryProps) -> any
-type MapDefinitionFn = (story: any) -> any
+type MapStoryFn = (story: unknown) -> (props: StoryProps) -> unknown
+type MapDefinitionFn = (story: unknown) -> unknown
 
 export type Storybook = {
 	storyRoots: { Instance },

--- a/src/types.luau
+++ b/src/types.luau
@@ -23,7 +23,7 @@ export type ReservedStoryProps = {
 }
 
 export type StoryProps = {
-	[string]: any,
+	[string]: unknown,
 }
 
 export type RenderLifecycle = {


### PR DESCRIPTION
# Problem

`StoryProps`, `StoryPackages`, and the `mapStory`/`mapDefinition` signatures type their values as `any`, so consumer-provided props, packages, and middleware silently opt out of type checking wherever they flow. `ExtraStoryProps` already models the same kind of boundary with `unknown`.

# Solution

Type all three maps and both middleware signatures with `unknown`, and narrow at the point of use instead:

- Each renderer casts the `mapDefinition` result back to the `LoadedStory` shape it mounts.
- The Fusion and Vide renderers name the shape their transformed controls take, `FusionValue` objects and Vide `source` functions, instead of letting `any` blur the raw and wrapped control maps together.
- Spec fixtures annotate the tables and callbacks that previously relied on `any`'s implicit widening, following the `ExtraStoryProps` pattern.

Stacked on #145 for the `ExtraStoryProps` precedent; retarget to `main` once the multi-story stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)